### PR TITLE
fix invalid literal for int() error

### DIFF
--- a/connect/settings.py
+++ b/connect/settings.py
@@ -75,7 +75,7 @@ env = environ.Env(
     ROCKET_USERNAME=(str, None),
     ROCKET_PASSWORD=(str, None),
     ROCKET_TEST_MODE=(bool, False),
-    VERIFICATION_AMOUNT=(int, 1)
+    VERIFICATION_AMOUNT=(float, 1)
 )
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
@@ -445,7 +445,7 @@ BILLING_COST_PER_WHATSAPP = env.float("BILLING_COST_PER_WHATSAPP")
 
 TOKEN_EXTERNAL_AUTHENTICATION = env.str("TOKEN_EXTERNAL_AUTHENTICATION")
 
-VERIFICATION_AMOUNT = env.int("VERIFICATION_AMOUNT")
+VERIFICATION_AMOUNT = env.float("VERIFICATION_AMOUNT")
 
 # Rocket
 ROCKET_CLIENT_ID = env.str("ROCKET_CLIENT_ID")


### PR DESCRIPTION
- change verification_amount `env.int()` to `env.float()`