### PR TITLE
 Project and User APIToken internal endpoint

### DIFF
--- a/connect/api/v1/internal/flows/flows_rest_client.py
+++ b/connect/api/v1/internal/flows/flows_rest_client.py
@@ -147,3 +147,12 @@ class FlowsRESTClient:
             json=body
         )
         return dict(status=response.status_code)
+
+    def get_user_api_token(self, project_uuid: str, user_email: str):
+        params = dict(org=project_uuid, user=user_email)
+        response = requests.get(
+            url=f"{self.base_url}/api/v2/internals/users/api-token",
+            params=params,
+            headers=self.authentication_instance.headers
+        )
+        return response

--- a/connect/api/v1/project/serializers.py
+++ b/connect/api/v1/project/serializers.py
@@ -538,7 +538,7 @@ class TemplateProjectSerializer(serializers.ModelSerializer):
 
 
 class UserAPITokenSerializer(serializers.Serializer):
-    user_email = serializers.EmailField(required=True)
+    user = serializers.EmailField(required=True)
     project_uuid = project_uuid = serializers.UUIDField(required=True)
 
     def validate_project_uuid(self, value):

--- a/connect/api/v1/project/serializers.py
+++ b/connect/api/v1/project/serializers.py
@@ -535,3 +535,15 @@ class TemplateProjectSerializer(serializers.ModelSerializer):
         }
 
         return data
+
+
+class UserAPITokenSerializer(serializers.Serializer):
+    user_email = serializers.EmailField(required=True)
+    project_uuid = project_uuid = serializers.UUIDField(required=True)
+
+    def validate_project_uuid(self, value):
+        try:
+            Project.objects.get(uuid=value)
+        except Project.DoesNotExist:
+            raise serializers.ValidationError("This project does not exist")
+        return value

--- a/connect/api/v1/project/serializers.py
+++ b/connect/api/v1/project/serializers.py
@@ -539,7 +539,7 @@ class TemplateProjectSerializer(serializers.ModelSerializer):
 
 class UserAPITokenSerializer(serializers.Serializer):
     user = serializers.EmailField(required=True)
-    project_uuid = project_uuid = serializers.UUIDField(required=True)
+    project_uuid = serializers.UUIDField(required=True)
 
     def validate_project_uuid(self, value):
         try:


### PR DESCRIPTION
Adds an endpoint that allows you to retrieve the `APIToken` from specified User and Project.
It takes 2 query parameters
- `project_uuid`: UUID of an existing project
- `user`: Email of an existing user  

and returns a JSON containing its schema:
```json
{
  "type": "object",
  "required": ["user", "api_token", "org"],
  "properties": {
      "user": {"type": "string"},
      "org": {"type": "string"},
      "api_token": {"type": "string"}
  }
}
```