### PR TITLE
feat: Add UpdateProjectConfig endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.41.0
+  - feat: Add UpdateProjectConfig endpoint
+
 # 3.40.1
   - feat: update agentic cx texts
   - feat: Enhance ProjectAdmin search functionality by adding UUID field

--- a/connect/api/v2/commerce/serializers.py
+++ b/connect/api/v2/commerce/serializers.py
@@ -155,3 +155,7 @@ class CreateVtexProjectSerializer(serializers.Serializer):
 
 class SetVtexHostStoreSerializer(serializers.Serializer):
     vtex_host_store = serializers.URLField(required=True)
+
+
+class UpdateProjectConfigSerializer(serializers.Serializer):
+    config = serializers.DictField(required=True, allow_empty=False)

--- a/connect/api/v2/commerce/tests.py
+++ b/connect/api/v2/commerce/tests.py
@@ -24,6 +24,7 @@ from connect.common.mocks import StripeMockGateway
 from connect.usecases.commerce.create_vtex_project import CreateVtexProjectUseCase
 from connect.usecases.commerce.dto import CreateVtexProjectDTO
 from connect.usecases.commerce.set_vtex_host_store import SetVtexHostStoreUseCase
+from connect.usecases.commerce.update_project_config import UpdateProjectConfigUseCase
 
 
 @override_settings(USE_EDA_PERMISSIONS=False)  # Disable EDA to avoid RabbitMQ issues
@@ -669,3 +670,210 @@ class SetVtexHostStoreUseCaseTestCase(APITestCase):
 
         with self.assertRaises(Project.DoesNotExist):
             use_case.execute(str(uuid.uuid4()), "https://www.example.com/")
+
+
+@override_settings(USE_EDA_PERMISSIONS=False)
+class UpdateProjectConfigViewTestCase(APITestCase):
+    """Tests for PATCH /v2/commerce/projects/<uuid>/config/"""
+
+    @patch("connect.authentication.signals.RabbitmqPublisher")
+    @patch("connect.common.signals.RabbitmqPublisher")
+    @patch("connect.common.signals.update_user_permission_project")
+    @patch("connect.billing.get_gateway")
+    def setUp(
+        self,
+        mock_get_gateway,
+        mock_permission,
+        mock_rabbitmq_common,
+        mock_rabbitmq_auth,
+    ):
+        mock_get_gateway.return_value = StripeMockGateway()
+        mock_permission.return_value = True
+        mock_rabbitmq_common.return_value = Mock()
+        mock_rabbitmq_auth.return_value = Mock()
+
+        self.client = APIClient()
+        self.user, self.token = create_user_and_token("configuser")
+
+        content_type = ContentType.objects.get_for_model(User)
+        permission, _ = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            name="can communicate internally",
+            content_type=content_type,
+        )
+        self.user.user_permissions.add(permission)
+        self.client.force_authenticate(user=self.user)
+
+        self.organization = Organization.objects.create(
+            name="config-org",
+            description="Organization config-org",
+            organization_billing__cycle=BillingPlan.BILLING_CYCLE_MONTHLY,
+            organization_billing__plan=BillingPlan.PLAN_TRIAL,
+        )
+        self.project = Project.objects.create(
+            name="config-project",
+            organization=self.organization,
+            vtex_account="config-store",
+            flow_organization=uuid.uuid4(),
+            project_type=TypeProject.COMMERCE,
+        )
+
+    def _url(self, project_uuid=None):
+        uid = project_uuid or str(self.project.uuid)
+        return reverse("update-project-config", kwargs={"project_uuid": uid})
+
+    @patch(
+        "connect.usecases.commerce.update_project_config.UpdateProjectUseCase"
+    )
+    def test_update_config_successfully(self, mock_update_uc):
+        """PATCH with valid config dict returns 200 and persists the values."""
+        mock_update_uc.return_value = Mock()
+
+        response = self.client.patch(
+            self._url(),
+            {"config": {"vtex_host_store": "https://www.mystore.com.br/"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response.data["config"]["vtex_host_store"],
+            "https://www.mystore.com.br/",
+        )
+
+        self.project.refresh_from_db()
+        self.assertEqual(
+            self.project.config["vtex_host_store"],
+            "https://www.mystore.com.br/",
+        )
+
+    @patch(
+        "connect.usecases.commerce.update_project_config.UpdateProjectUseCase"
+    )
+    def test_merges_with_existing_config(self, mock_update_uc):
+        """New keys should be added without removing existing ones."""
+        mock_update_uc.return_value = Mock()
+
+        self.project.config = {"store_type": "vtex-io"}
+        self.project.save(update_fields=["config"])
+
+        response = self.client.patch(
+            self._url(),
+            {"config": {"vtex_host_store": "https://www.mystore.com.br/"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.config["store_type"], "vtex-io")
+        self.assertEqual(
+            self.project.config["vtex_host_store"],
+            "https://www.mystore.com.br/",
+        )
+
+    @patch(
+        "connect.usecases.commerce.update_project_config.UpdateProjectUseCase"
+    )
+    def test_overwrite_existing_key(self, mock_update_uc):
+        """Sending an existing key with a new value should overwrite it."""
+        mock_update_uc.return_value = Mock()
+
+        self.project.config = {"store_type": "vtex-io"}
+        self.project.save(update_fields=["config"])
+
+        response = self.client.patch(
+            self._url(),
+            {"config": {"store_type": "vtex-cms"}},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.config["store_type"], "vtex-cms")
+
+    def test_empty_config_returns_400(self):
+        """Sending an empty config dict should fail validation."""
+        response = self.client.patch(
+            self._url(), {"config": {}}, format="json"
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_missing_config_returns_400(self):
+        """Sending an empty body should fail validation."""
+        response = self.client.patch(self._url(), {}, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_project_not_found_returns_404(self):
+        """Using a non-existent project UUID should return 404."""
+        fake_uuid = str(uuid.uuid4())
+        response = self.client.patch(
+            self._url(fake_uuid),
+            {"config": {"key": "value"}},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+
+@override_settings(USE_EDA_PERMISSIONS=False)
+class UpdateProjectConfigUseCaseTestCase(APITestCase):
+    """Unit tests for UpdateProjectConfigUseCase."""
+
+    @patch("connect.authentication.signals.RabbitmqPublisher")
+    @patch("connect.common.signals.RabbitmqPublisher")
+    @patch("connect.common.signals.update_user_permission_project")
+    @patch("connect.billing.get_gateway")
+    def setUp(
+        self,
+        mock_get_gateway,
+        mock_permission,
+        mock_rabbitmq_common,
+        mock_rabbitmq_auth,
+    ):
+        mock_get_gateway.return_value = StripeMockGateway()
+        mock_permission.return_value = True
+        mock_rabbitmq_common.return_value = Mock()
+        mock_rabbitmq_auth.return_value = Mock()
+
+        self.organization = Organization.objects.create(
+            name="uc-config-org",
+            description="Organization uc-config-org",
+            organization_billing__cycle=BillingPlan.BILLING_CYCLE_MONTHLY,
+            organization_billing__plan=BillingPlan.PLAN_TRIAL,
+        )
+        self.project = Project.objects.create(
+            name="uc-config-project",
+            organization=self.organization,
+            vtex_account="uc-config-store",
+            flow_organization=uuid.uuid4(),
+            project_type=TypeProject.COMMERCE,
+        )
+
+    def test_execute_merges_config_and_publishes(self):
+        """execute() should merge config keys and call EDA publisher."""
+        mock_update = Mock()
+        use_case = UpdateProjectConfigUseCase(update_project_usecase=mock_update)
+
+        self.project.config = {"existing_key": "existing_value"}
+        self.project.save(update_fields=["config"])
+
+        result = use_case.execute(
+            str(self.project.uuid),
+            {"new_key": "new_value"},
+        )
+
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.config["existing_key"], "existing_value")
+        self.assertEqual(self.project.config["new_key"], "new_value")
+        self.assertEqual(result["config"]["existing_key"], "existing_value")
+        self.assertEqual(result["config"]["new_key"], "new_value")
+        mock_update.send_updated_project.assert_called_once_with(
+            self.project, user_email=""
+        )
+
+    def test_project_not_found_raises(self):
+        """execute() should raise Project.DoesNotExist for unknown UUID."""
+        mock_update = Mock()
+        use_case = UpdateProjectConfigUseCase(update_project_usecase=mock_update)
+
+        with self.assertRaises(Project.DoesNotExist):
+            use_case.execute(str(uuid.uuid4()), {"key": "value"})

--- a/connect/api/v2/commerce/views.py
+++ b/connect/api/v2/commerce/views.py
@@ -10,12 +10,14 @@ from connect.api.v2.commerce.serializers import (
     CommerceSerializer,
     CreateVtexProjectSerializer,
     SetVtexHostStoreSerializer,
+    UpdateProjectConfigSerializer,
 )
 from connect.api.v2.paginations import CustomCursorPagination
 from connect.common.models import Organization, Project
 from connect.usecases.commerce.create_vtex_project import CreateVtexProjectUseCase
 from connect.usecases.commerce.dto import CreateVtexProjectDTO
 from connect.usecases.commerce.set_vtex_host_store import SetVtexHostStoreUseCase
+from connect.usecases.commerce.update_project_config import UpdateProjectConfigUseCase
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +67,27 @@ class SetVtexHostStoreView(views.APIView):
             result = SetVtexHostStoreUseCase().execute(
                 project_uuid=project_uuid,
                 vtex_host_store=serializer.validated_data["vtex_host_store"],
+            )
+        except Project.DoesNotExist:
+            return Response(
+                {"detail": "Project not found."},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        return Response(result, status=status.HTTP_200_OK)
+
+
+class UpdateProjectConfigView(views.APIView):
+    permission_classes = [CanCommunicateInternally]
+
+    def patch(self, request, project_uuid):
+        serializer = UpdateProjectConfigSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            result = UpdateProjectConfigUseCase().execute(
+                project_uuid=project_uuid,
+                config=serializer.validated_data["config"],
             )
         except Project.DoesNotExist:
             return Response(

--- a/connect/api/v2/routers.py
+++ b/connect/api/v2/routers.py
@@ -31,6 +31,7 @@ from connect.api.v2.commerce.views import (
     CommerceOrganizationViewSet,
     CreateVtexProjectView,
     SetVtexHostStoreView,
+    UpdateProjectConfigView,
 )
 from connect.api.v2.organizations import views as organization_views
 from connect.api.v2.projects import views as project_views
@@ -158,10 +159,15 @@ urlpatterns = [
         CreateVtexProjectView.as_view(),
         name="create-vtex-project",
     ),
-    path(
+    path( # TODO: deprecated, can be removed in the near future
         "commerce/projects/<project_uuid>/set-vtex-host-store/",
         SetVtexHostStoreView.as_view(),
         name="set-vtex-host-store",
+    ),
+    path(
+        "commerce/projects/<project_uuid>/config/",
+        UpdateProjectConfigView.as_view(),
+        name="update-project-config",
     ),
     path("auth/", KeycloakAuthView.as_view(), name="keycloak-auth"),
 ]

--- a/connect/usecases/commerce/update_project_config.py
+++ b/connect/usecases/commerce/update_project_config.py
@@ -1,0 +1,23 @@
+import logging
+
+from connect.common.models import Project
+from connect.usecases.project.update_project import UpdateProjectUseCase
+
+logger = logging.getLogger(__name__)
+
+
+class UpdateProjectConfigUseCase:
+    """Merges the given keys into the project config and publishes an EDA update."""
+
+    def __init__(self, update_project_usecase: UpdateProjectUseCase = None):
+        self._update_project = update_project_usecase or UpdateProjectUseCase()
+
+    def execute(self, project_uuid: str, config: dict) -> dict:
+        project = Project.objects.get(uuid=project_uuid)
+
+        project.config.update(config)
+        project.save(update_fields=["config"])
+
+        self._update_project.send_updated_project(project, user_email="")
+
+        return {"project_uuid": str(project.uuid), "config": project.config}


### PR DESCRIPTION
### What

Add a generic PATCH endpoint (`/v2/commerce/projects/{project_uuid}/config/`) that accepts arbitrary key-value pairs and merges them into the project's `config` JSONField. Only the provided keys are updated; existing keys remain untouched.

**Changed files:**
- `connect/api/v2/commerce/serializers.py` — new `UpdateProjectConfigSerializer`
- `connect/usecases/commerce/update_project_config.py` — new `UpdateProjectConfigUseCase`
- `connect/api/v2/commerce/views.py` — new `UpdateProjectConfigView`
- `connect/api/v2/routers.py` — route registration
- `connect/api/v2/commerce/tests.py` — view-level and use-case-level tests

### Why

The existing approach requires a dedicated endpoint, serializer, and use case for each config field (e.g., `SetVtexHostStoreView` for `vtex_host_store`). This doesn't scale as new config keys are needed. A single generic PATCH endpoint eliminates the need to create new endpoints for every new config field.
