### PR TITLE
chore: Remove social media links from base email template footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.41.1
+  - Remove social media links from base email template footer
+
 # 3.41.0
   - feat: Add UpdateProjectConfig endpoint
 

--- a/connect/authentication/templates/authentication/emails/base.html
+++ b/connect/authentication/templates/authentication/emails/base.html
@@ -26,21 +26,6 @@
       <footer style="padding: 0 32px; font-family: 'Lato', sans-serif; margin: auto; text-align: center;">
         <div style="margin: 0 auto 32px auto;">
           <div id="separator" style="width: 100%; height: 1px; background: #D0D3D9; margin-bottom: 24px;"></div>
-          <div style="margin: 0 auto 24px auto; font-family: 'Lato', sans-serif; font-weight: 700;">
-            <a style="cursor: pointer; margin-right: 32px; color: #00A49F; text-decoration: none;" target="_blank" href="https://weni.ai/">
-              {% trans 'Our site' %}
-            </a>
-            <a style="cursor: pointer; margin-right: 32px; color: #00A49F; text-decoration: none;" target="_blank" href="https://www.facebook.com/WeniAi">
-              Facebook
-            </a>
-            <a style="cursor: pointer; margin-right: 32px; color: #00A49F; text-decoration: none;" target="_blank" href="https://www.instagram.com/weni.ai/">
-              Instagram
-            </a>
-            <a style="cursor: pointer; margin-right: 0px; color: #00A49F; text-decoration: none;" target="_blank" href="https://www.linkedin.com/company/weniai/mycompany/">
-              Linkedin
-            </a>
-          </div>
-          <div id="separator" style="width: 100%; height: 1px; background: #D0D3D9; margin-bottom: 24px;"></div>
           <div style="font-family: 'Lato', sans-serif; font-style: normal; font-weight: normal; font-size: 12px; line-height: 20px; text-align: center; color: #3B414D">
             {% trans '2026 © VTEX CX Platform. All rights reserved.' %}
           </div>


### PR DESCRIPTION
### What

Remove the social media links section (website, Facebook, Instagram, LinkedIn) from the base email template footer.

### Why

These links reference the old Weni branding and are no longer relevant after the rebranding to VTEX CX Platform.

Made with [Cursor](https://cursor.com)