### PR TITLE
feat: Adds cached plan-status endpoint for retail consumption

### DIFF
--- a/connect/api/v2/internals/test_plan_status.py
+++ b/connect/api/v2/internals/test_plan_status.py
@@ -1,0 +1,100 @@
+import json
+import uuid
+
+from django.core.cache import cache
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+from unittest.mock import patch
+
+from connect.api.v1.tests.utils import create_user_and_token
+from connect.api.v2.internals.views import InternalProjectPlanStatusView
+from connect.common.mocks import StripeMockGateway
+from connect.common.models import (
+    BillingPlan,
+    Organization,
+    OrganizationRole,
+    Project,
+)
+
+
+class InternalProjectPlanStatusViewTestCase(TestCase):
+    @patch("connect.common.signals.update_user_permission_project")
+    @patch("connect.billing.get_gateway")
+    @patch(
+        "connect.api.v1.internal.flows.flows_rest_client.FlowsRESTClient.update_user_permission_project"
+    )
+    @patch(
+        "connect.api.v1.internal.integrations.integrations_rest_client.IntegrationsRESTClient.update_user_permission_project"
+    )
+    def setUp(
+        self, integrations_rest, flows_rest, mock_get_gateway, mock_permission
+    ):
+        integrations_rest.side_effect = [200, 200]
+        flows_rest.side_effect = [200, 200]
+        mock_get_gateway.return_value = StripeMockGateway()
+        mock_permission.return_value = True
+
+        self.factory = APIRequestFactory()
+        self.user, _ = create_user_and_token("plan_status_view_user")
+
+        self.org = Organization.objects.create(
+            name="Plan Status View Org",
+            description="Org for plan status view tests",
+            inteligence_organization=1,
+            organization_billing__cycle=BillingPlan.BILLING_CYCLE_MONTHLY,
+            organization_billing__plan=BillingPlan.PLAN_TRIAL,
+        )
+        self.org.authorizations.create(
+            user=self.user, role=OrganizationRole.ADMIN.value
+        )
+        self.project = Project.objects.create(
+            name="Plan Status View Project",
+            flow_organization=uuid.uuid4(),
+            organization=self.org,
+        )
+        cache.clear()
+
+    def tearDown(self):
+        cache.clear()
+
+    def _request(self, project_uuid):
+        path = f"/v2/internals/connect/projects/{project_uuid}/plan-status"
+        request = self.factory.get(path)
+        view = InternalProjectPlanStatusView.as_view()
+        response = view(request, project_uuid=project_uuid)
+        response.render()
+        return response, json.loads(response.content)
+
+    @patch("connect.api.v1.internal.permissions.ModuleHasPermission.has_permission")
+    def test_returns_plan_status_payload(self, module_has_permission):
+        module_has_permission.return_value = True
+
+        response, content = self._request(str(self.project.uuid))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(content["plan"], BillingPlan.PLAN_TRIAL)
+        self.assertTrue(content["is_trial"])
+        self.assertTrue(content["is_trial_active"])
+        self.assertTrue(content["is_active"])
+        self.assertFalse(content["is_suspended"])
+        self.assertEqual(content["project_uuid"], str(self.project.uuid))
+        self.assertEqual(content["organization_uuid"], str(self.org.uuid))
+        self.assertNotIn("trial_end_date", content)
+        self.assertNotIn("days_till_trial_end", content)
+
+    @patch("connect.api.v1.internal.permissions.ModuleHasPermission.has_permission")
+    def test_returns_404_for_unknown_project(self, module_has_permission):
+        module_has_permission.return_value = True
+
+        response, _ = self._request(str(uuid.uuid4()))
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch("connect.api.v1.internal.permissions.ModuleHasPermission.has_permission")
+    def test_returns_403_without_internal_permission(self, module_has_permission):
+        module_has_permission.return_value = False
+
+        response, _ = self._request(str(self.project.uuid))
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/connect/api/v2/internals/views.py
+++ b/connect/api/v2/internals/views.py
@@ -14,6 +14,10 @@ from connect.api.v2.internals.serializers import (
     CRMOrganizationSerializer,
     InternalProjectsListSerializer,
 )
+from connect.api.v2.projects.serializers import ProjectPlanStatusSerializer
+from connect.usecases.project.get_project_plan_status import (
+    GetProjectPlanStatusUseCase,
+)
 from connect.api.v2.internals.filters import CRMOrganizationFilter
 from connect.api.v2.internals.permissions import ProjectsAPITokenPermission
 from connect.api.v2.internals.paginations import ProjectsPageNumberPagination
@@ -137,6 +141,30 @@ class CRMOrganizationViewSet(
     def retrieve(self, request, *args, **kwargs):
         """Retrieve a specific organization by UUID"""
         return super().retrieve(request, *args, **kwargs)
+
+
+class InternalProjectPlanStatusView(views.APIView):
+    """Return the cached billing plan status for a project.
+
+    Service-to-service endpoint consumed by the retail/commerce module to check
+    whether a project is on trial. Responses are cached in Redis and
+    automatically invalidated whenever the underlying BillingPlan or
+    Organization changes.
+    """
+
+    permission_classes = [ModuleHasPermission]
+
+    @swagger_auto_schema(
+        operation_description=(
+            "GET /v2/internals/connect/projects/<project_uuid>/plan-status"
+        ),
+        responses={200: ProjectPlanStatusSerializer},
+        tags=["Internal"],
+    )
+    def get(self, request, project_uuid, **kwargs):
+        payload = GetProjectPlanStatusUseCase().execute(project_uuid=project_uuid)
+        serializer = ProjectPlanStatusSerializer(payload)
+        return Response(serializer.data)
 
 
 class InternalProjectsListView(views.APIView):

--- a/connect/api/v2/projects/serializers.py
+++ b/connect/api/v2/projects/serializers.py
@@ -625,6 +625,18 @@ class ProjectBillingSerializer(serializers.Serializer):
     days_till_trial_end = serializers.IntegerField()
 
 
+class ProjectPlanStatusSerializer(serializers.Serializer):
+    """Lightweight payload returned by the `plan-status` internal endpoint."""
+
+    project_uuid = serializers.UUIDField()
+    organization_uuid = serializers.UUIDField(allow_null=True)
+    plan = serializers.CharField(allow_null=True)
+    is_trial = serializers.BooleanField()
+    is_trial_active = serializers.BooleanField()
+    is_active = serializers.BooleanField()
+    is_suspended = serializers.BooleanField()
+
+
 class ProjectDetailSerializer(serializers.Serializer):
     uuid = serializers.UUIDField()
     name = serializers.CharField()

--- a/connect/api/v2/routers.py
+++ b/connect/api/v2/routers.py
@@ -159,7 +159,7 @@ urlpatterns = [
         CreateVtexProjectView.as_view(),
         name="create-vtex-project",
     ),
-    path( # TODO: deprecated, can be removed in the near future
+    path(  # TODO: deprecated, can be removed in the near future
         "commerce/projects/<project_uuid>/set-vtex-host-store/",
         SetVtexHostStoreView.as_view(),
         name="set-vtex-host-store",

--- a/connect/api/v2/routers.py
+++ b/connect/api/v2/routers.py
@@ -187,4 +187,9 @@ urlpatterns += [
         "internals/connect/projects",
         connect_internal_views.InternalProjectsListView.as_view(),
     ),
+    path(
+        "internals/connect/projects/<project_uuid>/plan-status",
+        connect_internal_views.InternalProjectPlanStatusView.as_view(),
+        name="internal-project-plan-status",
+    ),
 ]

--- a/connect/common/apps.py
+++ b/connect/common/apps.py
@@ -7,3 +7,9 @@ class CommonConfig(AppConfig):
     def ready(self):
         from .signals import create_service_status  # noqa: F401
         from .signals import create_service_default_in_all_user  # noqa: F401
+        from .signals import (  # noqa: F401
+            invalidate_plan_status_on_billing_delete,
+            invalidate_plan_status_on_billing_save,
+            invalidate_plan_status_on_organization_save,
+            invalidate_plan_status_on_project_delete,
+        )

--- a/connect/common/signals.py
+++ b/connect/common/signals.py
@@ -8,6 +8,7 @@ from django.utils import timezone
 from connect.authentication.models import User
 from connect.common.exceptions import ProjectAuthorizationException
 from connect.common.models import (
+    BillingPlan,
     ChatsRole,
     Project,
     Service,
@@ -18,6 +19,10 @@ from connect.common.models import (
     RequestRocketPermission,
     RequestChatsPermission,
     OpenedProject,
+)
+from connect.usecases.project.get_project_plan_status import (
+    invalidate_organization_plan_status,
+    invalidate_project_plan_status,
 )
 from connect.celery import app as celery_app
 from connect.api.v1.internal.chats.chats_rest_client import ChatsRESTClient
@@ -110,6 +115,33 @@ def update_organization(instance, **kwargs):
                 eda_publisher.publish_organization_deactivated(instance.uuid)
             else:
                 eda_publisher.publish_organization_activated(instance.uuid)
+
+
+@receiver(post_save, sender=Organization)
+def invalidate_plan_status_on_organization_save(sender, instance, **kwargs):
+    """Drop cached plan status when org-level fields that affect it change."""
+    update_fields = kwargs.get("update_fields") or set()
+    if update_fields and "is_suspended" not in update_fields:
+        return
+    invalidate_organization_plan_status(instance)
+
+
+@receiver(post_save, sender=BillingPlan)
+def invalidate_plan_status_on_billing_save(sender, instance, **kwargs):
+    """Drop cached plan status whenever the BillingPlan changes."""
+    invalidate_organization_plan_status(instance.organization)
+
+
+@receiver(post_delete, sender=BillingPlan)
+def invalidate_plan_status_on_billing_delete(sender, instance, **kwargs):
+    """Drop cached plan status when a BillingPlan is deleted."""
+    invalidate_organization_plan_status(instance.organization)
+
+
+@receiver(post_delete, sender=Project)
+def invalidate_plan_status_on_project_delete(sender, instance, **kwargs):
+    """Drop the project's cached plan status when it is removed."""
+    invalidate_project_plan_status(instance.uuid)
 
 
 @receiver(post_delete, sender=ProjectAuthorization)

--- a/connect/settings.py
+++ b/connect/settings.py
@@ -86,6 +86,7 @@ env = environ.Env(
     USE_FLOW_REST=(bool, True),
     PLAN_TRIAL_PRICE=(int, 0),
     PLAN_TRIAL_LIMIT=(int, 100),
+    PLAN_STATUS_CACHE_TTL=(int, 900),
     PLAN_START_LIMIT=(int, 200),
     PLAN_START_PRICE=(int, 390),
     PLAN_SCALE_LIMIT=(int, 500),
@@ -512,6 +513,11 @@ VERIFICATION_AMOUNT = env.float("VERIFICATION_AMOUNT")
 
 PLAN_TRIAL_PRICE = env.int("PLAN_TRIAL_PRICE")
 PLAN_TRIAL_LIMIT = env.int("PLAN_TRIAL_LIMIT")
+
+# TTL (seconds) for the cached project plan status payload returned by the
+# internal `plan-status` endpoint. Cache entries are also invalidated proactively
+# via signals whenever a BillingPlan or Organization.is_suspended changes.
+PLAN_STATUS_CACHE_TTL = env.int("PLAN_STATUS_CACHE_TTL")
 
 PLAN_START_LIMIT = env.int("PLAN_START_LIMIT")
 PLAN_START_PRICE = env.int("PLAN_START_PRICE")

--- a/connect/usecases/project/get_project_plan_status.py
+++ b/connect/usecases/project/get_project_plan_status.py
@@ -1,0 +1,134 @@
+"""Use case for retrieving the cached billing plan status of a project.
+
+The status is consumed by internal services (e.g. the retail/commerce module)
+that need to know, with high frequency, whether a project is on trial. The
+result is cached in Redis to avoid hitting the database on every request and
+proactively invalidated by signals whenever the underlying BillingPlan or
+Organization changes.
+"""
+
+import logging
+from typing import Any, Dict, Optional
+
+from django.conf import settings
+from django.core.cache import cache
+
+from connect.common.models import BillingPlan, Project
+from connect.usecases.project.exceptions import ProjectNotFoundError
+
+logger = logging.getLogger(__name__)
+
+CACHE_KEY_TEMPLATE = "project:plan-status:{project_uuid}"
+
+
+def build_cache_key(project_uuid: str) -> str:
+    """Return the canonical cache key for a project's plan status."""
+    return CACHE_KEY_TEMPLATE.format(project_uuid=str(project_uuid))
+
+
+def _empty_payload(project_uuid, organization_uuid=None) -> Dict[str, Any]:
+    """Return a default payload for projects without a BillingPlan."""
+    return {
+        "project_uuid": str(project_uuid),
+        "organization_uuid": (
+            str(organization_uuid) if organization_uuid else None
+        ),
+        "plan": None,
+        "is_trial": False,
+        "is_trial_active": False,
+        "is_active": False,
+        "is_suspended": False,
+    }
+
+
+class GetProjectPlanStatusUseCase:
+    """Return the billing plan status payload for a given project."""
+
+    def __init__(self, cache_backend=None, ttl: Optional[int] = None) -> None:
+        self._cache = cache_backend or cache
+        self._ttl = ttl if ttl is not None else getattr(
+            settings, "PLAN_STATUS_CACHE_TTL", 900
+        )
+
+    def execute(self, project_uuid: str) -> Dict[str, Any]:
+        cache_key = build_cache_key(project_uuid)
+
+        cached = self._cache.get(cache_key)
+        if cached is not None:
+            logger.debug(
+                "plan-status cache hit", extra={"project_uuid": str(project_uuid)}
+            )
+            return cached
+
+        payload = self._build_payload(project_uuid)
+        self._cache.set(cache_key, payload, self._ttl)
+        logger.debug(
+            "plan-status cache miss; payload cached",
+            extra={"project_uuid": str(project_uuid), "ttl": self._ttl},
+        )
+        return payload
+
+    def _build_payload(self, project_uuid: str) -> Dict[str, Any]:
+        # Fetch only the raw columns we need with a single SQL query.
+        # `.values()` skips Project/Organization/BillingPlan model instantiation
+        # (and their signals/FieldTracker overhead), which keeps cache misses
+        # cheap on this hot path.
+        row = (
+            BillingPlan.objects.filter(
+                organization__project__uuid=project_uuid
+            )
+            .values(
+                "plan",
+                "is_active",
+                "organization__uuid",
+                "organization__is_suspended",
+            )
+            .first()
+        )
+
+        if row is None:
+            # No BillingPlan attached: confirm the project itself exists so we
+            # can return a 404 instead of a misleading "no plan" payload.
+            project = (
+                Project.objects.filter(uuid=project_uuid)
+                .values("organization__uuid")
+                .first()
+            )
+            if project is None:
+                raise ProjectNotFoundError()
+            return _empty_payload(
+                project_uuid=project_uuid,
+                organization_uuid=project["organization__uuid"],
+            )
+
+        plan = row["plan"]
+        is_active = bool(row["is_active"])
+        is_suspended = bool(row["organization__is_suspended"])
+        is_trial = plan == BillingPlan.PLAN_TRIAL
+
+        return {
+            "project_uuid": str(project_uuid),
+            "organization_uuid": str(row["organization__uuid"]),
+            "plan": plan,
+            "is_trial": is_trial,
+            "is_trial_active": is_trial and is_active and not is_suspended,
+            "is_active": is_active,
+            "is_suspended": is_suspended,
+        }
+
+
+def invalidate_project_plan_status(project_uuid) -> None:
+    """Drop the cached plan status for a single project."""
+    cache.delete(build_cache_key(project_uuid))
+
+
+def invalidate_organization_plan_status(organization) -> None:
+    """Drop the cached plan status for every project of an organization."""
+    project_uuids = list(
+        organization.project.values_list("uuid", flat=True)
+    )
+    if not project_uuids:
+        return
+    cache.delete_many(
+        [build_cache_key(project_uuid) for project_uuid in project_uuids]
+    )

--- a/connect/usecases/project/tests/test_get_project_plan_status.py
+++ b/connect/usecases/project/tests/test_get_project_plan_status.py
@@ -1,0 +1,147 @@
+import uuid
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+from unittest.mock import patch
+from rest_framework.exceptions import NotFound
+
+from connect.api.v1.tests.utils import create_user_and_token
+from connect.common.mocks import StripeMockGateway
+from connect.common.models import (
+    BillingPlan,
+    Organization,
+    OrganizationRole,
+    Project,
+)
+from connect.usecases.project.get_project_plan_status import (
+    GetProjectPlanStatusUseCase,
+    build_cache_key,
+    invalidate_organization_plan_status,
+    invalidate_project_plan_status,
+)
+
+
+@override_settings(PLAN_STATUS_CACHE_TTL=60)
+class GetProjectPlanStatusUseCaseTestCase(TestCase):
+    @patch("connect.common.signals.update_user_permission_project")
+    @patch("connect.billing.get_gateway")
+    @patch(
+        "connect.api.v1.internal.flows.flows_rest_client.FlowsRESTClient.update_user_permission_project"
+    )
+    @patch(
+        "connect.api.v1.internal.integrations.integrations_rest_client.IntegrationsRESTClient.update_user_permission_project"
+    )
+    def setUp(self, integrations_rest, flows_rest, mock_get_gateway, mock_permission):
+        integrations_rest.side_effect = [200, 200]
+        flows_rest.side_effect = [200, 200]
+        mock_get_gateway.return_value = StripeMockGateway()
+        mock_permission.return_value = True
+
+        self.user, _ = create_user_and_token("plan_status_user")
+
+        self.org = Organization.objects.create(
+            name="Plan Status Org",
+            description="Org for plan status tests",
+            inteligence_organization=1,
+            organization_billing__cycle=BillingPlan.BILLING_CYCLE_MONTHLY,
+            organization_billing__plan=BillingPlan.PLAN_TRIAL,
+        )
+        self.org.authorizations.create(
+            user=self.user, role=OrganizationRole.ADMIN.value
+        )
+        self.project = Project.objects.create(
+            name="Plan Status Project",
+            flow_organization=uuid.uuid4(),
+            organization=self.org,
+        )
+
+        cache.clear()
+        self.use_case = GetProjectPlanStatusUseCase()
+
+    def tearDown(self):
+        cache.clear()
+
+    def test_execute_returns_trial_payload(self):
+        result = self.use_case.execute(project_uuid=str(self.project.uuid))
+
+        self.assertEqual(result["project_uuid"], str(self.project.uuid))
+        self.assertEqual(result["organization_uuid"], str(self.org.uuid))
+        self.assertEqual(result["plan"], BillingPlan.PLAN_TRIAL)
+        self.assertTrue(result["is_trial"])
+        self.assertTrue(result["is_trial_active"])
+        self.assertTrue(result["is_active"])
+        self.assertFalse(result["is_suspended"])
+        self.assertEqual(
+            set(result.keys()),
+            {
+                "project_uuid",
+                "organization_uuid",
+                "plan",
+                "is_trial",
+                "is_trial_active",
+                "is_active",
+                "is_suspended",
+            },
+        )
+
+    def test_is_trial_active_false_when_org_suspended(self):
+        self.org.is_suspended = True
+        self.org.save(update_fields=["is_suspended"])
+
+        result = self.use_case.execute(project_uuid=str(self.project.uuid))
+
+        self.assertTrue(result["is_trial"])
+        self.assertFalse(result["is_trial_active"])
+        self.assertTrue(result["is_suspended"])
+
+    def test_execute_raises_not_found_for_unknown_project(self):
+        with self.assertRaises(NotFound):
+            self.use_case.execute(project_uuid=str(uuid.uuid4()))
+
+    def test_payload_is_cached_between_calls(self):
+        cache_key = build_cache_key(self.project.uuid)
+        self.assertIsNone(cache.get(cache_key))
+
+        first = self.use_case.execute(project_uuid=str(self.project.uuid))
+        self.assertIsNotNone(cache.get(cache_key))
+
+        with patch.object(
+            GetProjectPlanStatusUseCase, "_build_payload"
+        ) as build_mock:
+            second = self.use_case.execute(project_uuid=str(self.project.uuid))
+            build_mock.assert_not_called()
+
+        self.assertEqual(first, second)
+
+    def test_invalidate_project_plan_status_drops_cache(self):
+        self.use_case.execute(project_uuid=str(self.project.uuid))
+        self.assertIsNotNone(cache.get(build_cache_key(self.project.uuid)))
+
+        invalidate_project_plan_status(self.project.uuid)
+
+        self.assertIsNone(cache.get(build_cache_key(self.project.uuid)))
+
+    def test_invalidate_organization_plan_status_drops_cache(self):
+        self.use_case.execute(project_uuid=str(self.project.uuid))
+        self.assertIsNotNone(cache.get(build_cache_key(self.project.uuid)))
+
+        invalidate_organization_plan_status(self.org)
+
+        self.assertIsNone(cache.get(build_cache_key(self.project.uuid)))
+
+    def test_billing_change_plan_invalidates_cache(self):
+        self.use_case.execute(project_uuid=str(self.project.uuid))
+        self.assertIsNotNone(cache.get(build_cache_key(self.project.uuid)))
+
+        self.org.organization_billing.change_plan(BillingPlan.PLAN_START)
+
+        self.assertIsNone(cache.get(build_cache_key(self.project.uuid)))
+
+    def test_org_suspend_invalidates_cache(self):
+        self.use_case.execute(project_uuid=str(self.project.uuid))
+        self.assertIsNotNone(cache.get(build_cache_key(self.project.uuid)))
+
+        self.org.is_suspended = True
+        self.org.save(update_fields=["is_suspended"])
+
+        self.assertIsNone(cache.get(build_cache_key(self.project.uuid)))


### PR DESCRIPTION
What
Adds the internal endpoint GET /v2/internals/connect/projects/<project_uuid>/plan-status, which returns the project's plan status (plan, is_trial, is_trial_active, is_active, is_suspended + uuids).

The response is cached in Redis (TTL PLAN_STATUS_CACHE_TTL, default 900s) and automatically invalidated via signals whenever the BillingPlan changes or the Organization is suspended/reactivated.

Why
The retail module needs to check with high frequency whether a project is on an active trial. Existing routes (/v1/organization/org/<uuid>, /v2/organizations/<uuid>, /v2/projects/<uuid>/detail) return heavy payloads with no caching, making them unsuitable for this use case.

The new route is lightweight, cached and always consistent — without touching models, existing signals, or creating migrations on the billing core.