### PR TITLE
feat: Enhance InternalProjectViewSet to support retrieval of project language details

### DIFF
--- a/connect/api/v2/internals/serializers.py
+++ b/connect/api/v2/internals/serializers.py
@@ -233,6 +233,13 @@ class CRMOrganizationSerializer(serializers.ModelSerializer):
         return CRMProjectSerializer(projects, many=True).data
 
 
+class InternalProjectLanguageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Project
+        fields = ["uuid", "language"]
+        read_only_fields = ["uuid", "language"]
+
+
 class InternalProjectsListSerializer(serializers.ModelSerializer):
     """
     Simplified serializer for internal projects list API.

--- a/connect/api/v2/internals/views.py
+++ b/connect/api/v2/internals/views.py
@@ -11,6 +11,7 @@ from connect.api.v2.internals.serializers import (
     OrganizationAISerializer,
     CustomParameterSerializer,
     InternalProjectSerializer,
+    InternalProjectLanguageSerializer,
     CRMOrganizationSerializer,
     InternalProjectsListSerializer,
 )
@@ -36,6 +37,11 @@ class InternalProjectViewSet(ModelViewSet):
     queryset = Project.objects.all()
     lookup_field = "uuid"
     serializer_class = InternalProjectSerializer
+
+    def get_serializer_class(self):
+        if self.action == "retrieve":
+            return InternalProjectLanguageSerializer
+        return super().get_serializer_class()
 
 
 class AIGetOrganizationView(views.APIView):

--- a/connect/api/v2/routers.py
+++ b/connect/api/v2/routers.py
@@ -180,7 +180,7 @@ urlpatterns += [
     path(
         "internals/connect/projects/<uuid>",
         connect_internal_views.InternalProjectViewSet.as_view(
-            {"patch": "partial_update"}
+            {"patch": "partial_update", "get": "retrieve"}
         ),
     ),
     path(


### PR DESCRIPTION
# What
Adds internal endpoint to retrieve current project language

# Why
Nexus service needs the project language info to send a localized default error message to the user when an agent response fails