### PR TITLE
feat: Implement Send Data Export Email functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 3.47.0
+  - feat: Implement Send Data Export Email functionality
+
+# 3.46.2
+  - fix: uuid type 
+
+# 3.46.1
+  - Add custom non-inline organizations
+
 # 3.46.0
   - feat: Adds business verification result notification endpoint
 

--- a/connect/api/v2/commerce/serializers.py
+++ b/connect/api/v2/commerce/serializers.py
@@ -184,7 +184,11 @@ class SendDataExportEmailSerializer(serializers.Serializer):
     start_date = serializers.DateField(required=True)
     end_date = serializers.DateField(required=True)
     template = serializers.CharField(required=True)
-    status = serializers.ChoiceField(choices=DATA_EXPORT_STATUSES, required=True)
+    status = serializers.ListField(
+        child=serializers.ChoiceField(choices=DATA_EXPORT_STATUSES),
+        required=True,
+        allow_empty=False,
+    )
     language = serializers.ChoiceField(
         choices=settings.LANGUAGES,
         required=False,

--- a/connect/api/v2/commerce/serializers.py
+++ b/connect/api/v2/commerce/serializers.py
@@ -165,3 +165,29 @@ class SetVtexHostStoreSerializer(serializers.Serializer):
 
 class UpdateProjectConfigSerializer(serializers.Serializer):
     config = serializers.DictField(required=True, allow_empty=False)
+
+
+DATA_EXPORT_STATUSES = (
+    "all",
+    "processing",
+    "skipped",
+    "error",
+    "sent",
+    "delivered",
+    "read",
+)
+
+
+class SendDataExportEmailSerializer(serializers.Serializer):
+    user_email = serializers.EmailField(required=True)
+    file_url = serializers.URLField(required=True)
+    start_date = serializers.DateField(required=True)
+    end_date = serializers.DateField(required=True)
+    template = serializers.CharField(required=True)
+    status = serializers.ChoiceField(choices=DATA_EXPORT_STATUSES, required=True)
+    language = serializers.ChoiceField(
+        choices=settings.LANGUAGES,
+        required=False,
+        allow_null=True,
+        default=None,
+    )

--- a/connect/api/v2/commerce/tests.py
+++ b/connect/api/v2/commerce/tests.py
@@ -877,3 +877,60 @@ class UpdateProjectConfigUseCaseTestCase(APITestCase):
 
         with self.assertRaises(Project.DoesNotExist):
             use_case.execute(str(uuid.uuid4()), {"key": "value"})
+
+
+class SendDataExportEmailViewTestCase(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user, self.token = create_user_and_token("dataexportuser")
+
+        content_type = ContentType.objects.get_for_model(User)
+        permission, _ = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            name="can communicate internally",
+            content_type=content_type,
+        )
+        self.user.user_permissions.add(permission)
+        self.client.force_authenticate(user=self.user)
+
+        self.url = reverse("commerce-send-data-export-email")
+        self.payload = {
+            "user_email": "customer@example.com",
+            "file_url": "https://files.example.com/export.csv",
+            "start_date": "2026-04-01",
+            "end_date": "2026-05-01",
+            "template": "all",
+            "status": "delivered",
+        }
+
+    @patch("connect.api.v2.commerce.views.SendDataExportEmailUseCase")
+    def test_returns_200_and_dispatches(self, use_case_class):
+        use_case_class.return_value.execute.return_value = True
+
+        response = self.client.post(self.url, self.payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"sent": True})
+
+        dto = use_case_class.return_value.execute.call_args.args[0]
+        self.assertEqual(dto.user_email, "customer@example.com")
+        self.assertEqual(dto.status, "delivered")
+        self.assertEqual(dto.template, "all")
+
+    @patch("connect.api.v2.commerce.views.SendDataExportEmailUseCase")
+    def test_rejects_invalid_status(self, use_case_class):
+        payload = {**self.payload, "status": "unknown"}
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        use_case_class.return_value.execute.assert_not_called()
+
+    def test_returns_403_without_internal_permission(self):
+        other_user, _ = create_user_and_token("nopermission")
+        client = APIClient()
+        client.force_authenticate(user=other_user)
+
+        response = client.post(self.url, self.payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/connect/api/v2/commerce/tests.py
+++ b/connect/api/v2/commerce/tests.py
@@ -900,7 +900,7 @@ class SendDataExportEmailViewTestCase(APITestCase):
             "start_date": "2026-04-01",
             "end_date": "2026-05-01",
             "template": "all",
-            "status": "delivered",
+            "status": ["sent", "delivered", "read"],
         }
 
     @patch("connect.api.v2.commerce.views.SendDataExportEmailUseCase")
@@ -914,12 +914,12 @@ class SendDataExportEmailViewTestCase(APITestCase):
 
         dto = use_case_class.return_value.execute.call_args.args[0]
         self.assertEqual(dto.user_email, "customer@example.com")
-        self.assertEqual(dto.status, "delivered")
+        self.assertEqual(dto.status, ["sent", "delivered", "read"])
         self.assertEqual(dto.template, "all")
 
     @patch("connect.api.v2.commerce.views.SendDataExportEmailUseCase")
     def test_rejects_invalid_status(self, use_case_class):
-        payload = {**self.payload, "status": "unknown"}
+        payload = {**self.payload, "status": ["unknown"]}
 
         response = self.client.post(self.url, payload, format="json")
 

--- a/connect/api/v2/commerce/views.py
+++ b/connect/api/v2/commerce/views.py
@@ -9,13 +9,15 @@ from connect.api.v2.commerce.permissions import CanCommunicateInternally
 from connect.api.v2.commerce.serializers import (
     CommerceSerializer,
     CreateVtexProjectSerializer,
+    SendDataExportEmailSerializer,
     SetVtexHostStoreSerializer,
     UpdateProjectConfigSerializer,
 )
 from connect.api.v2.paginations import CustomCursorPagination
 from connect.common.models import Organization, Project
 from connect.usecases.commerce.create_vtex_project import CreateVtexProjectUseCase
-from connect.usecases.commerce.dto import CreateVtexProjectDTO
+from connect.usecases.commerce.dto import CreateVtexProjectDTO, SendDataExportEmailDTO
+from connect.usecases.commerce.send_data_export_email import SendDataExportEmailUseCase
 from connect.usecases.commerce.set_vtex_host_store import SetVtexHostStoreUseCase
 from connect.usecases.commerce.update_project_config import UpdateProjectConfigUseCase
 
@@ -75,6 +77,19 @@ class SetVtexHostStoreView(views.APIView):
             )
 
         return Response(result, status=status.HTTP_200_OK)
+
+
+class SendDataExportEmailView(views.APIView):
+    permission_classes = [CanCommunicateInternally]
+
+    def post(self, request):
+        serializer = SendDataExportEmailSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dto = SendDataExportEmailDTO(**serializer.validated_data)
+        sent = SendDataExportEmailUseCase().execute(dto)
+
+        return Response({"sent": bool(sent)}, status=status.HTTP_200_OK)
 
 
 class UpdateProjectConfigView(views.APIView):

--- a/connect/api/v2/routers.py
+++ b/connect/api/v2/routers.py
@@ -30,6 +30,7 @@ from connect.api.v2.template_projects.views import (
 from connect.api.v2.commerce.views import (
     CommerceOrganizationViewSet,
     CreateVtexProjectView,
+    SendDataExportEmailView,
     SetVtexHostStoreView,
     UpdateProjectConfigView,
 )
@@ -173,6 +174,11 @@ urlpatterns = [
         "commerce/projects/<project_uuid>/config/",
         UpdateProjectConfigView.as_view(),
         name="update-project-config",
+    ),
+    path(
+        "commerce/send-data-export-email/",
+        SendDataExportEmailView.as_view(),
+        name="commerce-send-data-export-email",
     ),
     path("auth/", KeycloakAuthView.as_view(), name="keycloak-auth"),
 ]

--- a/connect/common/templates/common/emails/data_export/email.html
+++ b/connect/common/templates/common/emails/data_export/email.html
@@ -1,0 +1,29 @@
+{% extends 'authentication/emails/base.html' %}
+{% load i18n %}
+
+{% block main-content %}
+<section style="margin: 24px auto; padding: 0 32px">
+  <div style="font-family: 'Lato', sans-serif; font-weight: 700; font-size: 14px; line-height: 20px; color: #3b414d">
+    {% trans 'Your data export has been processed and ready for download.' %}
+  </div>
+  <div style="font-family: 'Lato', sans-serif; font-size: 14px; line-height: 20px; color: #3b414d; margin-top: 12px">
+    {% trans "Here's what you requested:" %}
+  </div>
+  <ul style="font-family: 'Lato', sans-serif; font-size: 14px; line-height: 20px; color: #3b414d; margin-top: 12px; padding-left: 21px">
+    <li>{% trans 'Period' %}: {{ period }}</li>
+    <li>{% trans 'Template' %}: {{ template_label }}</li>
+    <li>{% trans 'Status' %}: {{ status_label }}</li>
+  </ul>
+  <div style="font-family: 'Lato', sans-serif; font-size: 14px; line-height: 20px; color: #3b414d; margin-top: 12px">
+    {% trans "If the data doesn't match what you expected, you can go back to the platform and generate a new export with adjusted filters." %}
+  </div>
+  <a href="{{ file_url }}" style="text-decoration: none">
+    <div style="padding: 12px 16px; text-align: center; background: #00a49f; border-radius: 8px; color: #fff; font-family: 'Lato', sans-serif; font-weight: 600; font-size: 14px; line-height: 20px; margin-top: 12px">
+      {% trans 'Download File' %}
+    </div>
+  </a>
+  <div style="font-family: 'Lato', sans-serif; font-size: 14px; line-height: 20px; color: #3b414d; margin-top: 12px">
+    VTEX CX Team
+  </div>
+</section>
+{% endblock %}

--- a/connect/common/templates/common/emails/data_export/email.txt
+++ b/connect/common/templates/common/emails/data_export/email.txt
@@ -1,0 +1,13 @@
+{% load i18n %}{% trans 'Your data export has been processed and ready for download.' %}
+
+{% trans "Here's what you requested:" %}
+
+- {% trans 'Period' %}: {{ period }}
+- {% trans 'Template' %}: {{ template_label }}
+- {% trans 'Status' %}: {{ status_label }}
+
+{% trans "If the data doesn't match what you expected, you can go back to the platform and generate a new export with adjusted filters." %}
+
+{% trans 'Download File' %}: {{ file_url }}
+
+VTEX CX Team

--- a/connect/locale/pt_BR/LC_MESSAGES/django.po
+++ b/connect/locale/pt_BR/LC_MESSAGES/django.po
@@ -1695,6 +1695,77 @@ msgstr "Português"
 msgid "Spanish"
 msgstr "Espanhol"
 
+#: connect/usecases/commerce/send_data_export_email.py
+msgid "Your data export is ready"
+msgstr "Sua exportação de dados está pronta"
+
+#: connect/common/templates/common/emails/data_export/email.html
+#: connect/common/templates/common/emails/data_export/email.txt
+msgid "Your data export has been processed and ready for download."
+msgstr "A exportação dos seus dados foi processada e está pronta para download."
+
+#: connect/common/templates/common/emails/data_export/email.html
+#: connect/common/templates/common/emails/data_export/email.txt
+msgid "Here's what you requested:"
+msgstr "Veja o que você solicitou:"
+
+#: connect/common/templates/common/emails/data_export/email.html
+#: connect/common/templates/common/emails/data_export/email.txt
+msgid "Period"
+msgstr "Período"
+
+#: connect/common/templates/common/emails/data_export/email.html
+#: connect/common/templates/common/emails/data_export/email.txt
+msgid "Template"
+msgstr "Template"
+
+#: connect/common/templates/common/emails/data_export/email.html
+#: connect/common/templates/common/emails/data_export/email.txt
+msgid "Status"
+msgstr "Status"
+
+#: connect/common/templates/common/emails/data_export/email.html
+#: connect/common/templates/common/emails/data_export/email.txt
+msgid ""
+"If the data doesn't match what you expected, you can go back to the platform "
+"and generate a new export with adjusted filters."
+msgstr ""
+"Se os dados não corresponderem ao esperado, volte à plataforma e gere uma "
+"nova exportação com filtros ajustados."
+
+#: connect/common/templates/common/emails/data_export/email.html
+#: connect/common/templates/common/emails/data_export/email.txt
+msgid "Download File"
+msgstr "Baixar arquivo"
+
+#: connect/usecases/commerce/send_data_export_email.py
+msgid "All"
+msgstr "Todos"
+
+#: connect/usecases/commerce/send_data_export_email.py
+msgid "Processing"
+msgstr "Processando"
+
+#: connect/usecases/commerce/send_data_export_email.py
+msgid "Skipped"
+msgstr "Ignorado"
+
+#: connect/usecases/commerce/send_data_export_email.py
+msgid "Error"
+msgstr "Erro"
+
+#: connect/usecases/commerce/send_data_export_email.py
+msgid "Sent"
+msgstr "Enviado"
+
+#: connect/usecases/commerce/send_data_export_email.py
+msgid "Delivered"
+msgstr "Entregue"
+
+#: connect/usecases/commerce/send_data_export_email.py
+msgid "Read"
+msgstr "Lido"
+
 #~ msgid "WhatsApp"
 #~ msgstr "WhatsApp"
 

--- a/connect/usecases/commerce/dto.py
+++ b/connect/usecases/commerce/dto.py
@@ -1,4 +1,6 @@
 from dataclasses import dataclass
+from datetime import date
+from typing import Optional
 
 
 @dataclass(frozen=True)
@@ -8,3 +10,14 @@ class CreateVtexProjectDTO:
     language: str
     organization_name: str
     project_name: str
+
+
+@dataclass(frozen=True)
+class SendDataExportEmailDTO:
+    user_email: str
+    file_url: str
+    start_date: date
+    end_date: date
+    template: str
+    status: str
+    language: Optional[str] = None

--- a/connect/usecases/commerce/dto.py
+++ b/connect/usecases/commerce/dto.py
@@ -1,6 +1,6 @@
 from dataclasses import dataclass
 from datetime import date
-from typing import Optional
+from typing import List, Optional
 
 
 @dataclass(frozen=True)
@@ -19,5 +19,5 @@ class SendDataExportEmailDTO:
     start_date: date
     end_date: date
     template: str
-    status: str
+    status: List[str]
     language: Optional[str] = None

--- a/connect/usecases/commerce/send_data_export_email.py
+++ b/connect/usecases/commerce/send_data_export_email.py
@@ -6,6 +6,7 @@ available for download.
 
 import logging
 from datetime import date
+from typing import List
 
 from django.conf import settings
 from django.utils import translation
@@ -54,7 +55,7 @@ class SendDataExportEmailUseCase:
                 "file_url": dto.file_url,
                 "period": self._build_period(dto.start_date, dto.end_date, language),
                 "template_label": self._build_template_label(dto.template),
-                "status_label": str(STATUS_LABELS[dto.status]),
+                "status_label": self._build_status_label(dto.status),
             }
             send_email(
                 subject=str(_("Your data export is ready")),
@@ -81,6 +82,9 @@ class SendDataExportEmailUseCase:
     def _build_period(self, start_date: date, end_date: date, language: str) -> str:
         date_format = "%m/%d/%Y" if language == ENGLISH_LANGUAGE else "%d/%m/%Y"
         return f"{start_date.strftime(date_format)} ~ {end_date.strftime(date_format)}"
+
+    def _build_status_label(self, statuses: List[str]) -> str:
+        return ", ".join(str(STATUS_LABELS[status]) for status in statuses)
 
     def _build_template_label(self, template: str) -> str:
         if template.lower() == ALL_TEMPLATE_OPTION:

--- a/connect/usecases/commerce/send_data_export_email.py
+++ b/connect/usecases/commerce/send_data_export_email.py
@@ -1,0 +1,88 @@
+"""Send the data export ready email to a commerce user.
+
+Triggered by the commerce module once an export file is processed and
+available for download.
+"""
+
+import logging
+from datetime import date
+
+from django.conf import settings
+from django.utils import translation
+from django.utils.translation import ugettext_lazy as _
+
+from connect.authentication.models import User
+from connect.common.utils import send_email
+from connect.usecases.commerce.dto import SendDataExportEmailDTO
+
+
+logger = logging.getLogger(__name__)
+
+
+TEMPLATE_TXT = "common/emails/data_export/email.txt"
+TEMPLATE_HTML = "common/emails/data_export/email.html"
+
+ENGLISH_LANGUAGE = "en-us"
+ALL_TEMPLATE_OPTION = "all"
+
+STATUS_LABELS = {
+    "all": _("All"),
+    "processing": _("Processing"),
+    "skipped": _("Skipped"),
+    "error": _("Error"),
+    "sent": _("Sent"),
+    "delivered": _("Delivered"),
+    "read": _("Read"),
+}
+
+
+class SendDataExportEmailUseCase:
+    """Render and send the data export email respecting the user language."""
+
+    def execute(self, dto: SendDataExportEmailDTO) -> bool:
+        if not settings.SEND_EMAILS:
+            logger.info(
+                f"SEND_EMAILS is disabled; skipping data export email "
+                f"to user_email={dto.user_email}"
+            )
+            return False
+
+        language = self._resolve_language(dto.user_email, dto.language)
+
+        with translation.override(language):
+            context = {
+                "file_url": dto.file_url,
+                "period": self._build_period(dto.start_date, dto.end_date, language),
+                "template_label": self._build_template_label(dto.template),
+                "status_label": str(STATUS_LABELS[dto.status]),
+            }
+            send_email(
+                subject=str(_("Your data export is ready")),
+                to=dto.user_email,
+                template_txt=TEMPLATE_TXT,
+                template_html=TEMPLATE_HTML,
+                context=context,
+            )
+
+        logger.info(
+            f"Data export email dispatched user_email={dto.user_email} "
+            f"status={dto.status} template={dto.template} language={language}"
+        )
+        return True
+
+    def _resolve_language(self, user_email: str, language: str) -> str:
+        if language:
+            return language
+        user = User.objects.filter(email=user_email).only("language").first()
+        if user and user.language:
+            return user.language
+        return settings.DEFAULT_LANGUAGE
+
+    def _build_period(self, start_date: date, end_date: date, language: str) -> str:
+        date_format = "%m/%d/%Y" if language == ENGLISH_LANGUAGE else "%d/%m/%Y"
+        return f"{start_date.strftime(date_format)} ~ {end_date.strftime(date_format)}"
+
+    def _build_template_label(self, template: str) -> str:
+        if template.lower() == ALL_TEMPLATE_OPTION:
+            return str(_("All"))
+        return template

--- a/connect/usecases/commerce/tests/test_send_data_export_email.py
+++ b/connect/usecases/commerce/tests/test_send_data_export_email.py
@@ -21,7 +21,7 @@ def _dto(**overrides) -> SendDataExportEmailDTO:
         start_date=date(2026, 4, 1),
         end_date=date(2026, 5, 1),
         template="all",
-        status="all",
+        status=["all"],
         language=None,
     )
     defaults.update(overrides)
@@ -68,11 +68,20 @@ class SendDataExportEmailUseCaseTestCase(TestCase):
         self.assertEqual(context["period"], "01/04/2026 ~ 01/05/2026")
 
     @patch("connect.usecases.commerce.send_data_export_email.send_email")
-    def test_status_enum_is_translated(self, mock_send):
-        self.use_case.execute(_dto(language="en-us", status="delivered"))
+    def test_single_status_enum_is_translated(self, mock_send):
+        self.use_case.execute(_dto(language="en-us", status=["delivered"]))
 
         context = mock_send.call_args.kwargs["context"]
         self.assertEqual(context["status_label"], "Delivered")
+
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_multiple_statuses_are_translated_and_joined(self, mock_send):
+        self.use_case.execute(
+            _dto(language="en-us", status=["sent", "delivered", "read"])
+        )
+
+        context = mock_send.call_args.kwargs["context"]
+        self.assertEqual(context["status_label"], "Sent, Delivered, Read")
 
     @patch("connect.usecases.commerce.send_data_export_email.send_email")
     def test_template_all_is_translated(self, mock_send):

--- a/connect/usecases/commerce/tests/test_send_data_export_email.py
+++ b/connect/usecases/commerce/tests/test_send_data_export_email.py
@@ -1,0 +1,114 @@
+"""Tests for SendDataExportEmailUseCase."""
+
+from datetime import date
+from unittest.mock import patch
+
+from django.test import TestCase, override_settings
+
+from connect.authentication.models import User
+from connect.usecases.commerce.dto import SendDataExportEmailDTO
+from connect.usecases.commerce.send_data_export_email import (
+    TEMPLATE_HTML,
+    TEMPLATE_TXT,
+    SendDataExportEmailUseCase,
+)
+
+
+def _dto(**overrides) -> SendDataExportEmailDTO:
+    defaults = dict(
+        user_email="customer@example.com",
+        file_url="https://files.example.com/export.csv",
+        start_date=date(2026, 4, 1),
+        end_date=date(2026, 5, 1),
+        template="all",
+        status="all",
+        language=None,
+    )
+    defaults.update(overrides)
+    return SendDataExportEmailDTO(**defaults)
+
+
+@override_settings(SEND_EMAILS=True, DEFAULT_LANGUAGE="en-us")
+class SendDataExportEmailUseCaseTestCase(TestCase):
+    def setUp(self):
+        self.use_case = SendDataExportEmailUseCase()
+        self.user = User.objects.create(
+            email="customer@example.com",
+            username="customer",
+            first_name="Alice",
+            language="pt-br",
+        )
+
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_sends_email_with_expected_context(self, mock_send):
+        result = self.use_case.execute(_dto(language="en-us"))
+
+        self.assertTrue(result)
+        mock_send.assert_called_once()
+        kwargs = mock_send.call_args.kwargs
+        self.assertEqual(kwargs["to"], "customer@example.com")
+        self.assertEqual(kwargs["template_txt"], TEMPLATE_TXT)
+        self.assertEqual(kwargs["template_html"], TEMPLATE_HTML)
+        self.assertEqual(
+            kwargs["context"]["file_url"], "https://files.example.com/export.csv"
+        )
+
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_period_uses_month_first_format_for_english(self, mock_send):
+        self.use_case.execute(_dto(language="en-us"))
+
+        context = mock_send.call_args.kwargs["context"]
+        self.assertEqual(context["period"], "04/01/2026 ~ 05/01/2026")
+
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_period_uses_day_first_format_for_portuguese(self, mock_send):
+        self.use_case.execute(_dto(language="pt-br"))
+
+        context = mock_send.call_args.kwargs["context"]
+        self.assertEqual(context["period"], "01/04/2026 ~ 01/05/2026")
+
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_status_enum_is_translated(self, mock_send):
+        self.use_case.execute(_dto(language="en-us", status="delivered"))
+
+        context = mock_send.call_args.kwargs["context"]
+        self.assertEqual(context["status_label"], "Delivered")
+
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_template_all_is_translated(self, mock_send):
+        self.use_case.execute(_dto(language="en-us", template="all"))
+
+        context = mock_send.call_args.kwargs["context"]
+        self.assertEqual(context["template_label"], "All")
+
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_template_other_value_is_passed_through(self, mock_send):
+        self.use_case.execute(_dto(language="en-us", template="Black Friday"))
+
+        context = mock_send.call_args.kwargs["context"]
+        self.assertEqual(context["template_label"], "Black Friday")
+
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_language_resolved_from_user_when_not_provided(self, mock_send):
+        self.use_case.execute(_dto(language=None))
+
+        context = mock_send.call_args.kwargs["context"]
+        self.assertEqual(context["period"], "01/04/2026 ~ 01/05/2026")
+
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_falls_back_to_default_language_for_unknown_user(self, mock_send):
+        result = self.use_case.execute(
+            _dto(user_email="unknown@example.com", language=None)
+        )
+
+        self.assertTrue(result)
+        context = mock_send.call_args.kwargs["context"]
+        self.assertEqual(context["period"], "04/01/2026 ~ 05/01/2026")
+
+    @override_settings(SEND_EMAILS=False)
+    @patch("connect.usecases.commerce.send_data_export_email.send_email")
+    def test_skips_when_send_emails_disabled(self, mock_send):
+        result = self.use_case.execute(_dto())
+
+        self.assertFalse(result)
+        mock_send.assert_not_called()


### PR DESCRIPTION
### What

Adds an internal commerce endpoint that sends the "data export ready" email to a user, rendered with the existing base email template, with localized copy and locale-aware date formatting.

- New endpoint `POST /v2/commerce/send-data-export-email/`.
- Request payload: `user_email`, `file_url`, `start_date`, `end_date`, `template`, `status`, optional `language`.
- `SendDataExportEmailSerializer` validates input (`DateField` dates, `status` choice enum, optional `language`).
- `SendDataExportEmailDTO` + `SendDataExportEmailUseCase` handle language resolution (explicit → user record → default), date formatting per language (`en-us` → MM/DD/YYYY, others → DD/MM/YYYY), `status` enum translation, and `template` translation only for the `all` option.
- New email templates `common/emails/data_export/email.html` and `email.txt` extending `authentication/emails/base.html` (base template unchanged).
- pt_BR translations added to `connect/locale/pt_BR/LC_MESSAGES/django.po` for all new strings (subject, body copy, labels, status enum, "All").
- Tests: use-case tests (date formats, status/template translation, language resolution, `SEND_EMAILS` guard) and view tests (200/400/403).

### Why

The commerce module needs to notify users by email when a data export is processed and ready for download. Centralizing this in weni-engine reuses the shared email template and translation pipeline, keeps the email rendering and per-language date handling consistent with the rest of the platform, and exposes it through the established internal (OIDC) authentication used by other commerce endpoints.
