### PR TITLE
fix: Add clicktracking attribute to download link in email template

### DIFF
--- a/connect/common/templates/common/emails/data_export/email.html
+++ b/connect/common/templates/common/emails/data_export/email.html
@@ -17,7 +17,7 @@
   <div style="font-family: 'Lato', sans-serif; font-size: 14px; line-height: 20px; color: #3b414d; margin-top: 12px">
     {% trans "If the data doesn't match what you expected, you can go back to the platform and generate a new export with adjusted filters." %}
   </div>
-  <a href="{{ file_url }}" style="text-decoration: none">
+  <a clicktracking="off" href="{{ file_url }}" style="text-decoration: none">
     <div style="padding: 12px 16px; text-align: center; background: #00a49f; border-radius: 8px; color: #fff; font-family: 'Lato', sans-serif; font-weight: 600; font-size: 14px; line-height: 20px; margin-top: 12px">
       {% trans 'Download File' %}
     </div>


### PR DESCRIPTION
## What
Adds the `clicktracking="off"` attribute to the "Download File" button anchor in the data export email template, so SendGrid no longer rewrites this link with its click-tracking proxy. Recipients now get the raw file_url as-is.

## Why
SendGrid's click tracking rewrites every link in the email, replacing the download URL with a proxy URL that isn't served over https. That broken scheme was causing issues when users tried to download their exported data. Per SendGrid's documentation, adding `clicktracking=off` inside the anchor (before href) excludes only this link from tracking while leaving tracking intact for all other links in the email.