### PR TITLE
feat: Add contract acceptance email endpoint with PDF attachment

### DIFF
--- a/connect/api/v2/commerce/serializers.py
+++ b/connect/api/v2/commerce/serializers.py
@@ -1,3 +1,6 @@
+import base64
+import binascii
+
 from django.conf import settings
 from django.contrib.auth import get_user_model
 
@@ -86,7 +89,7 @@ class CommerceSerializer(serializers.Serializer):
             "brain_on": True,
             "project_type": instance.project_type.value,
             "vtex_account": instance.vtex_account,
-            "inline_agent_switch": inline_agent_switch
+            "inline_agent_switch": inline_agent_switch,
         }
         rabbitmq_publisher = RabbitmqPublisher()
         rabbitmq_publisher.send_message(
@@ -195,3 +198,45 @@ class SendDataExportEmailSerializer(serializers.Serializer):
         allow_null=True,
         default=None,
     )
+
+
+# Reserve space for subject, body_html, field names and JSON framing within
+# Django's in-memory request body limit (DATA_UPLOAD_MAX_MEMORY_SIZE). Base64
+# inflates the PDF by ~33%, so the decoded limit is derived from the remaining
+# budget to avoid RequestDataTooBig before serializer validation runs.
+_CONTRACT_EMAIL_JSON_OVERHEAD_BYTES = 256 * 1024
+
+
+def _contract_pdf_max_size_bytes() -> int:
+    max_request_bytes = getattr(settings, "DATA_UPLOAD_MAX_MEMORY_SIZE", 2_621_440)
+    max_base64_bytes = max(max_request_bytes - _CONTRACT_EMAIL_JSON_OVERHEAD_BYTES, 0)
+    return int(max_base64_bytes * 3 / 4)
+
+
+CONTRACT_PDF_MAX_SIZE_BYTES = _contract_pdf_max_size_bytes()
+
+
+class SendContractAcceptanceEmailSerializer(serializers.Serializer):
+    user_email = serializers.EmailField(required=True)
+    acceptance_id = serializers.UUIDField(required=True)
+    subject = serializers.CharField(required=True)
+    body_html = serializers.CharField(required=True)
+    file_name = serializers.CharField(required=True)
+    file_base64 = serializers.CharField(required=True)
+
+    def validate_file_base64(self, value: str) -> str:
+        try:
+            decoded = base64.b64decode(value, validate=True)
+        except (binascii.Error, ValueError):
+            raise serializers.ValidationError("Invalid base64-encoded file.")
+
+        if not decoded:
+            raise serializers.ValidationError("Decoded file is empty.")
+
+        if len(decoded) > CONTRACT_PDF_MAX_SIZE_BYTES:
+            raise serializers.ValidationError(
+                f"Attachment exceeds the maximum size of "
+                f"{CONTRACT_PDF_MAX_SIZE_BYTES} bytes."
+            )
+
+        return value

--- a/connect/api/v2/commerce/tests.py
+++ b/connect/api/v2/commerce/tests.py
@@ -1,3 +1,4 @@
+import base64
 import uuid
 from unittest.mock import patch, Mock
 
@@ -918,3 +919,134 @@ class SendDataExportEmailViewTestCase(APITestCase):
         response = client.post(self.url, self.payload, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class SendContractAcceptanceEmailViewTestCase(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user, self.token = create_user_and_token("contractuser")
+
+        content_type = ContentType.objects.get_for_model(User)
+        permission, _ = Permission.objects.get_or_create(
+            codename="can_communicate_internally",
+            name="can communicate internally",
+            content_type=content_type,
+        )
+        self.user.user_permissions.add(permission)
+        self.client.force_authenticate(user=self.user)
+
+        self.url = reverse("commerce-send-contract-acceptance-email")
+        self.payload = {
+            "user_email": "customer@example.com",
+            "acceptance_id": str(uuid.uuid4()),
+            "subject": "Seu contrato Weni",
+            "body_html": "<p>Contrato aceito com sucesso</p>",
+            "file_name": "contract-v2.1.pdf",
+            "file_base64": base64.b64encode(b"%PDF-1.4 fake").decode(),
+        }
+
+    @patch("connect.api.v2.commerce.views.SendContractAcceptanceEmailUseCase")
+    def test_returns_200_and_dispatches(self, use_case_class):
+        use_case_class.return_value.execute.return_value = True
+
+        response = self.client.post(self.url, self.payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"sent": True})
+
+        dto = use_case_class.return_value.execute.call_args.args[0]
+        self.assertEqual(dto.user_email, "customer@example.com")
+        self.assertEqual(dto.subject, "Seu contrato Weni")
+        self.assertEqual(dto.body_html, "<p>Contrato aceito com sucesso</p>")
+        self.assertEqual(dto.file_name, "contract-v2.1.pdf")
+
+    @patch("connect.api.v2.commerce.views.SendContractAcceptanceEmailUseCase")
+    def test_rejects_invalid_base64(self, use_case_class):
+        payload = {**self.payload, "file_base64": "not-valid-base64!!!"}
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        use_case_class.return_value.execute.assert_not_called()
+
+    @patch("connect.api.v2.commerce.views.SendContractAcceptanceEmailUseCase")
+    def test_rejects_invalid_acceptance_id(self, use_case_class):
+        payload = {**self.payload, "acceptance_id": "not-a-uuid"}
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        use_case_class.return_value.execute.assert_not_called()
+
+    @patch("connect.api.v2.commerce.views.SendContractAcceptanceEmailUseCase")
+    def test_rejects_missing_required_fields(self, use_case_class):
+        response = self.client.post(self.url, {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        use_case_class.return_value.execute.assert_not_called()
+
+    def test_returns_403_without_internal_permission(self):
+        other_user, _ = create_user_and_token("nopermission-contract")
+        client = APIClient()
+        client.force_authenticate(user=other_user)
+
+        response = client.post(self.url, self.payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class SendContractAcceptanceEmailSerializerTestCase(APITestCase):
+    def _data(self, **overrides):
+        data = {
+            "user_email": "customer@example.com",
+            "acceptance_id": str(uuid.uuid4()),
+            "subject": "Seu contrato Weni",
+            "body_html": "<p>Contrato aceito com sucesso</p>",
+            "file_name": "contract-v2.1.pdf",
+            "file_base64": base64.b64encode(b"%PDF-1.4 fake").decode(),
+        }
+        data.update(overrides)
+        return data
+
+    def test_rejects_attachment_above_max_size(self):
+        from connect.api.v2.commerce.serializers import (
+            CONTRACT_PDF_MAX_SIZE_BYTES,
+            SendContractAcceptanceEmailSerializer,
+        )
+
+        oversized = base64.b64encode(b"a" * (CONTRACT_PDF_MAX_SIZE_BYTES + 1)).decode()
+        serializer = SendContractAcceptanceEmailSerializer(
+            data=self._data(file_base64=oversized)
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("file_base64", serializer.errors)
+
+    def test_rejects_empty_decoded_file(self):
+        from connect.api.v2.commerce.serializers import (
+            SendContractAcceptanceEmailSerializer,
+        )
+
+        serializer = SendContractAcceptanceEmailSerializer(
+            data=self._data(file_base64="")
+        )
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("file_base64", serializer.errors)
+
+    def test_pdf_limit_matches_request_body_budget(self):
+        from django.conf import settings
+
+        from connect.api.v2.commerce.serializers import (
+            CONTRACT_PDF_MAX_SIZE_BYTES,
+            _CONTRACT_EMAIL_JSON_OVERHEAD_BYTES,
+        )
+
+        max_request_bytes = settings.DATA_UPLOAD_MAX_MEMORY_SIZE
+        max_base64_bytes = max(
+            max_request_bytes - _CONTRACT_EMAIL_JSON_OVERHEAD_BYTES, 0
+        )
+        expected = int(max_base64_bytes * 3 / 4)
+
+        self.assertEqual(CONTRACT_PDF_MAX_SIZE_BYTES, expected)
+        self.assertLess(CONTRACT_PDF_MAX_SIZE_BYTES, 5 * 1024 * 1024)

--- a/connect/api/v2/commerce/views.py
+++ b/connect/api/v2/commerce/views.py
@@ -9,6 +9,7 @@ from connect.api.v2.commerce.permissions import CanCommunicateInternally
 from connect.api.v2.commerce.serializers import (
     CommerceSerializer,
     CreateVtexProjectSerializer,
+    SendContractAcceptanceEmailSerializer,
     SendDataExportEmailSerializer,
     SetVtexHostStoreSerializer,
     UpdateProjectConfigSerializer,
@@ -16,7 +17,14 @@ from connect.api.v2.commerce.serializers import (
 from connect.api.v2.paginations import CustomCursorPagination
 from connect.common.models import Organization, Project
 from connect.usecases.commerce.create_vtex_project import CreateVtexProjectUseCase
-from connect.usecases.commerce.dto import CreateVtexProjectDTO, SendDataExportEmailDTO
+from connect.usecases.commerce.dto import (
+    CreateVtexProjectDTO,
+    SendContractAcceptanceEmailDTO,
+    SendDataExportEmailDTO,
+)
+from connect.usecases.commerce.send_contract_acceptance_email import (
+    SendContractAcceptanceEmailUseCase,
+)
 from connect.usecases.commerce.send_data_export_email import SendDataExportEmailUseCase
 from connect.usecases.commerce.set_vtex_host_store import SetVtexHostStoreUseCase
 from connect.usecases.commerce.update_project_config import UpdateProjectConfigUseCase
@@ -88,6 +96,19 @@ class SendDataExportEmailView(views.APIView):
 
         dto = SendDataExportEmailDTO(**serializer.validated_data)
         sent = SendDataExportEmailUseCase().execute(dto)
+
+        return Response({"sent": bool(sent)}, status=status.HTTP_200_OK)
+
+
+class SendContractAcceptanceEmailView(views.APIView):
+    permission_classes = [CanCommunicateInternally]
+
+    def post(self, request):
+        serializer = SendContractAcceptanceEmailSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        dto = SendContractAcceptanceEmailDTO(**serializer.validated_data)
+        sent = SendContractAcceptanceEmailUseCase().execute(dto)
 
         return Response({"sent": bool(sent)}, status=status.HTTP_200_OK)
 

--- a/connect/api/v2/routers.py
+++ b/connect/api/v2/routers.py
@@ -30,6 +30,7 @@ from connect.api.v2.template_projects.views import (
 from connect.api.v2.commerce.views import (
     CommerceOrganizationViewSet,
     CreateVtexProjectView,
+    SendContractAcceptanceEmailView,
     SendDataExportEmailView,
     SetVtexHostStoreView,
     UpdateProjectConfigView,
@@ -179,6 +180,11 @@ urlpatterns = [
         "commerce/send-data-export-email/",
         SendDataExportEmailView.as_view(),
         name="commerce-send-data-export-email",
+    ),
+    path(
+        "commerce/send-contract-acceptance-email/",
+        SendContractAcceptanceEmailView.as_view(),
+        name="commerce-send-contract-acceptance-email",
     ),
     path("auth/", KeycloakAuthView.as_view(), name="keycloak-auth"),
 ]

--- a/connect/common/tests/test_utils.py
+++ b/connect/common/tests/test_utils.py
@@ -1,0 +1,58 @@
+"""Tests for email helpers in connect.common.utils."""
+
+from django.core import mail
+from django.test import TestCase, override_settings
+
+from connect.common.utils import send_html_email
+
+
+@override_settings(
+    SEND_EMAILS=True,
+    EMAIL_BACKEND="django.core.mail.backends.locmem.EmailBackend",
+    SENDGRID_UNSUBSCRIBE_GROUP_ID=None,
+)
+class SendHtmlEmailTestCase(TestCase):
+    def setUp(self):
+        mail.outbox = []
+
+    def test_sends_html_body_as_alternative_with_attachment(self):
+        send_html_email(
+            subject="Your Weni contract",
+            to="customer@example.com",
+            html_content="<p>Contract accepted</p>",
+            attachments=[("contract.pdf", b"%PDF-1.4 fake", "application/pdf")],
+        )
+
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        self.assertEqual(message.subject, "Your Weni contract")
+        self.assertEqual(message.to, ["customer@example.com"])
+        self.assertEqual(message.body, "Contract accepted")
+        self.assertEqual(
+            message.alternatives, [("<p>Contract accepted</p>", "text/html")]
+        )
+
+        filename, content, mimetype = message.attachments[0]
+        self.assertEqual(filename, "contract.pdf")
+        self.assertEqual(content, b"%PDF-1.4 fake")
+        self.assertEqual(mimetype, "application/pdf")
+
+    def test_uses_explicit_text_content_when_provided(self):
+        send_html_email(
+            subject="Your Weni contract",
+            to="customer@example.com",
+            html_content="<p>Contract accepted</p>",
+            text_content="Plain fallback",
+        )
+
+        self.assertEqual(mail.outbox[0].body, "Plain fallback")
+
+    @override_settings(SEND_EMAILS=False)
+    def test_skips_when_send_emails_disabled(self):
+        send_html_email(
+            subject="Your Weni contract",
+            to="customer@example.com",
+            html_content="<p>Contract accepted</p>",
+        )
+
+        self.assertEqual(len(mail.outbox), 0)

--- a/connect/common/utils.py
+++ b/connect/common/utils.py
@@ -3,6 +3,35 @@ import json
 from django.conf import settings
 from django.core.mail import EmailMultiAlternatives
 from django.template.loader import render_to_string
+from django.utils.html import strip_tags
+
+
+def _build_sendgrid_headers():
+    unsubscribe_group_id = getattr(settings, "SENDGRID_UNSUBSCRIBE_GROUP_ID", None)
+    if not unsubscribe_group_id:
+        return {}
+    return {"X-SMTPAPI": json.dumps({"asm": {"group_id": int(unsubscribe_group_id)}})}
+
+
+def _dispatch_email(subject, to, text_content, html_content=None, attachments=None):
+    """Build and send an email, attaching the HTML alternative and files.
+
+    ``attachments`` is an optional iterable of ``(filename, content, mimetype)``
+    tuples forwarded to ``EmailMultiAlternatives.attach``.
+    """
+    if not isinstance(to, list):
+        to = [to]
+
+    msg = EmailMultiAlternatives(
+        subject, text_content, None, to, headers=_build_sendgrid_headers()
+    )
+    if html_content:
+        msg.attach_alternative(html_content, "text/html")
+
+    for attachment in attachments or []:
+        msg.attach(*attachment)
+
+    return msg.send()
 
 
 def send_email(subject, to, template_txt, template_html=None, context=None):
@@ -13,22 +42,22 @@ def send_email(subject, to, template_txt, template_html=None, context=None):
         return
 
     text_content = render_to_string(template_txt, context)
-    html_content = None
-    if template_html:
-        html_content = render_to_string(template_html, context)
+    html_content = render_to_string(template_html, context) if template_html else None
 
-    unsubscribe_group_id = getattr(settings, "SENDGRID_UNSUBSCRIBE_GROUP_ID", None)
-    headers = {}
-    if unsubscribe_group_id:
-        headers["X-SMTPAPI"] = json.dumps(
-            {"asm": {"group_id": int(unsubscribe_group_id)}}
-        )
+    return _dispatch_email(subject, to, text_content, html_content)
 
-    if not isinstance(to, list):
-        to = [to]
 
-    msg = EmailMultiAlternatives(subject, text_content, None, to, headers=headers)
-    if html_content:
-        msg.attach_alternative(html_content, "text/html")
+def send_html_email(subject, to, html_content, text_content="", attachments=None):
+    """
+    Send an email from already-rendered subject and HTML body.
 
-    return msg.send()
+    Used when the caller owns composition/translation and the platform only
+    needs to deliver the message (e.g. transactional emails built upstream).
+    """
+    if not settings.SEND_EMAILS:
+        return
+
+    if not text_content and html_content:
+        text_content = strip_tags(html_content).strip()
+
+    return _dispatch_email(subject, to, text_content, html_content, attachments)

--- a/connect/usecases/commerce/dto.py
+++ b/connect/usecases/commerce/dto.py
@@ -1,3 +1,4 @@
+import uuid
 from dataclasses import dataclass
 from datetime import date
 from typing import List, Optional
@@ -21,3 +22,13 @@ class SendDataExportEmailDTO:
     template: str
     status: List[str]
     language: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class SendContractAcceptanceEmailDTO:
+    user_email: str
+    acceptance_id: uuid.UUID
+    subject: str
+    body_html: str
+    file_name: str
+    file_base64: str

--- a/connect/usecases/commerce/send_contract_acceptance_email.py
+++ b/connect/usecases/commerce/send_contract_acceptance_email.py
@@ -1,0 +1,66 @@
+"""Send the self-serve contract acceptance email to a commerce user.
+
+Triggered by the retail module once a customer accepts a self-serve
+contract. The retail owns subject/body composition and translation; this
+use case only delivers the message with the contract PDF attached.
+"""
+
+import base64
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+
+from connect.common.utils import send_html_email
+from connect.usecases.commerce.dto import SendContractAcceptanceEmailDTO
+
+
+logger = logging.getLogger(__name__)
+
+
+PDF_MIME_TYPE = "application/pdf"
+
+IDEMPOTENCY_KEY_PREFIX = "contract-acceptance-email"
+IDEMPOTENCY_TTL_SECONDS = 60 * 60 * 24 * 7  # 7 days
+
+
+class SendContractAcceptanceEmailUseCase:
+    """Deliver the contract acceptance email with the PDF attached.
+
+    Deduplicates by ``acceptance_id`` so retail retries do not deliver the
+    same contract twice.
+    """
+
+    def execute(self, dto: SendContractAcceptanceEmailDTO) -> bool:
+        if not settings.SEND_EMAILS:
+            logger.info(
+                f"SEND_EMAILS is disabled; skipping contract acceptance email "
+                f"to user_email={dto.user_email}"
+            )
+            return False
+
+        idempotency_key = f"{IDEMPOTENCY_KEY_PREFIX}:{dto.acceptance_id}"
+        if cache.get(idempotency_key):
+            logger.info(
+                f"Contract acceptance email already sent "
+                f"acceptance_id={dto.acceptance_id}; skipping"
+            )
+            return True
+
+        attachment = self._build_attachment(dto.file_name, dto.file_base64)
+        send_html_email(
+            subject=dto.subject,
+            to=dto.user_email,
+            html_content=dto.body_html,
+            attachments=[attachment],
+        )
+
+        cache.set(idempotency_key, True, IDEMPOTENCY_TTL_SECONDS)
+        logger.info(
+            f"Contract acceptance email dispatched user_email={dto.user_email} "
+            f"acceptance_id={dto.acceptance_id}"
+        )
+        return True
+
+    def _build_attachment(self, file_name: str, file_base64: str) -> tuple:
+        return (file_name, base64.b64decode(file_base64), PDF_MIME_TYPE)

--- a/connect/usecases/commerce/tests/test_send_contract_acceptance_email.py
+++ b/connect/usecases/commerce/tests/test_send_contract_acceptance_email.py
@@ -1,0 +1,91 @@
+"""Tests for SendContractAcceptanceEmailUseCase."""
+
+import base64
+import uuid
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from connect.usecases.commerce.dto import SendContractAcceptanceEmailDTO
+from connect.usecases.commerce.send_contract_acceptance_email import (
+    PDF_MIME_TYPE,
+    SendContractAcceptanceEmailUseCase,
+)
+
+
+PDF_BYTES = b"%PDF-1.4 fake-contract-content"
+PDF_BASE64 = base64.b64encode(PDF_BYTES).decode()
+
+
+def _dto(**overrides) -> SendContractAcceptanceEmailDTO:
+    defaults = dict(
+        user_email="customer@example.com",
+        acceptance_id=uuid.uuid4(),
+        subject="Seu contrato Weni",
+        body_html="<p>Contrato aceito com sucesso</p>",
+        file_name="contract-v2.1.pdf",
+        file_base64=PDF_BASE64,
+    )
+    defaults.update(overrides)
+    return SendContractAcceptanceEmailDTO(**defaults)
+
+
+@override_settings(
+    SEND_EMAILS=True,
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "contract-acceptance-email-tests",
+        }
+    },
+)
+class SendContractAcceptanceEmailUseCaseTestCase(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.use_case = SendContractAcceptanceEmailUseCase()
+
+    def tearDown(self):
+        cache.clear()
+
+    @patch("connect.usecases.commerce.send_contract_acceptance_email.send_html_email")
+    def test_sends_email_with_subject_body_and_attachment(self, mock_send):
+        result = self.use_case.execute(_dto())
+
+        self.assertTrue(result)
+        mock_send.assert_called_once()
+        kwargs = mock_send.call_args.kwargs
+        self.assertEqual(kwargs["to"], "customer@example.com")
+        self.assertEqual(kwargs["subject"], "Seu contrato Weni")
+        self.assertEqual(kwargs["html_content"], "<p>Contrato aceito com sucesso</p>")
+
+        attachment = kwargs["attachments"][0]
+        self.assertEqual(attachment[0], "contract-v2.1.pdf")
+        self.assertEqual(attachment[1], PDF_BYTES)
+        self.assertEqual(attachment[2], PDF_MIME_TYPE)
+
+    @patch("connect.usecases.commerce.send_contract_acceptance_email.send_html_email")
+    def test_is_idempotent_for_same_acceptance_id(self, mock_send):
+        dto = _dto()
+
+        first = self.use_case.execute(dto)
+        second = self.use_case.execute(dto)
+
+        self.assertTrue(first)
+        self.assertTrue(second)
+        mock_send.assert_called_once()
+
+    @patch("connect.usecases.commerce.send_contract_acceptance_email.send_html_email")
+    def test_distinct_acceptance_ids_send_separately(self, mock_send):
+        self.use_case.execute(_dto())
+        self.use_case.execute(_dto())
+
+        self.assertEqual(mock_send.call_count, 2)
+
+    @override_settings(SEND_EMAILS=False)
+    @patch("connect.usecases.commerce.send_contract_acceptance_email.send_html_email")
+    def test_skips_when_send_emails_disabled(self, mock_send):
+        result = self.use_case.execute(_dto())
+
+        self.assertFalse(result)
+        mock_send.assert_not_called()


### PR DESCRIPTION
## What

Adds `POST /v2/commerce/send-contract-acceptance-email/` for the retail
self-serve contract flow. The retail module sends a pre-rendered subject and
HTML body plus a base64-encoded PDF; Connect validates the payload, deduplicates
by `acceptance_id` (7-day cache TTL), and delivers the email with the PDF
attached as `application/pdf`.

Implementation follows the existing `send-data-export-email` pattern: thin view,
serializer validation, DTO, and framework-agnostic use case. A new
`send_html_email` helper in `connect/common/utils.py` handles pre-rendered HTML
(with automatic plain-text fallback via `strip_tags`) while keeping the legacy
`send_email` path unchanged.

PDF size limit is derived from Django's `DATA_UPLOAD_MAX_MEMORY_SIZE` to avoid
`RequestDataTooBig` before serializer validation (~1.69 MB decoded PDF with
default settings).

## Why

Retail-setup needs Connect to deliver signed self-serve contract PDFs by
transactional email after customer acceptance. Retail owns email composition
and translation; Connect only needs a reliable, idempotent delivery endpoint
using the same internal service-to-service auth as other commerce endpoints.
