### PR TITLE
feat: Publish project deleted EDA on v1 organization destroy

### DIFF
--- a/connect/api/v1/organization/views.py
+++ b/connect/api/v1/organization/views.py
@@ -77,6 +77,7 @@ from connect.usecases.organizations.update_sso_config import (
     UpdateOrganizationSSOConfigDTO,
     UpdateOrganizationSSOConfigUseCase,
 )
+from connect.usecases.project import ProjectEDAPublisher
 
 
 logger = logging.getLogger(__name__)
@@ -262,11 +263,20 @@ class OrganizationViewSet(
 
     def perform_destroy(self, instance):
         intelligence_organization = instance.inteligence_organization
+        user_email = self.request.user.email
+
+        eda_publisher = ProjectEDAPublisher()
+        for project in instance.project.all():
+            eda_publisher.publish_project_deleted(
+                project_uuid=project.uuid,
+                user_email=user_email,
+            )
+
         instance.delete()
         ai_client = IntelligenceRESTClient()
         ai_client.delete_organization(
             organization_id=intelligence_organization,
-            user_email=self.request.user.email,
+            user_email=user_email,
         )
 
     def update(self, request, *args, **kwargs):

--- a/connect/api/v1/tests/test_organization_destroy_eda.py
+++ b/connect/api/v1/tests/test_organization_destroy_eda.py
@@ -1,0 +1,76 @@
+import uuid as uuid_lib
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase, override_settings
+
+from connect.api.v1.organization.views import OrganizationViewSet
+from connect.authentication.models import User
+from connect.common.models import BillingPlan, Organization
+
+
+@override_settings(
+    USE_EDA_PERMISSIONS=False,
+    CACHES={
+        "default": {
+            "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+            "LOCATION": "organization-destroy-eda-tests",
+        }
+    },
+)
+class OrganizationDestroyEDATestCase(TestCase):
+    @patch("connect.authentication.signals.RabbitmqPublisher")
+    @patch("connect.common.signals.RabbitmqPublisher")
+    @patch("connect.billing.get_gateway")
+    def setUp(self, mock_get_gateway, mock_common_rabbitmq, mock_auth_rabbitmq):
+        from connect.common.mocks import StripeMockGateway
+
+        mock_get_gateway.return_value = StripeMockGateway()
+
+        self.user = User.objects.create_user("admin@user.com", "admin")
+        self.organization = Organization.objects.create(
+            name="Test Org",
+            inteligence_organization=123,
+            organization_billing__cycle=BillingPlan.BILLING_CYCLE_MONTHLY,
+            organization_billing__plan="free",
+        )
+        self.project_one = self.organization.project.create(
+            name="project one",
+            timezone="America/Sao_Paulo",
+            flow_organization=uuid_lib.uuid4(),
+        )
+        self.project_two = self.organization.project.create(
+            name="project two",
+            timezone="America/Sao_Paulo",
+            flow_organization=uuid_lib.uuid4(),
+        )
+
+        self.view = OrganizationViewSet()
+        self.view.request = MagicMock()
+        self.view.request.user = self.user
+
+    @patch("connect.api.v1.organization.views.IntelligenceRESTClient")
+    @patch("connect.api.v1.organization.views.ProjectEDAPublisher")
+    def test_perform_destroy_publishes_deleted_event_for_each_project(
+        self, mock_eda_publisher, mock_ai_client
+    ):
+        mock_publisher = MagicMock()
+        mock_eda_publisher.return_value = mock_publisher
+        mock_ai_client.return_value.delete_organization.return_value = None
+
+        organization_uuid = self.organization.uuid
+
+        self.view.perform_destroy(self.organization)
+
+        self.assertFalse(Organization.objects.filter(uuid=organization_uuid).exists())
+        self.assertEqual(mock_publisher.publish_project_deleted.call_count, 2)
+
+        published_uuids = {
+            call.kwargs["project_uuid"]
+            for call in mock_publisher.publish_project_deleted.call_args_list
+        }
+        self.assertEqual(
+            published_uuids,
+            {self.project_one.uuid, self.project_two.uuid},
+        )
+        for call in mock_publisher.publish_project_deleted.call_args_list:
+            self.assertEqual(call.kwargs["user_email"], self.user.email)

--- a/connect/api/v2/projects/views.py
+++ b/connect/api/v2/projects/views.py
@@ -125,16 +125,11 @@ class ProjectViewSet(
         return super(ProjectViewSet, self).create(request, *args, **kwargs)
 
     def perform_destroy(self, instance):
-        user_email = self.request.user.email
-        project_uuid = instance.uuid
-
-        # Publish delete event via EDA to notify Flows and Billing
         eda_publisher = ProjectEDAPublisher()
         eda_publisher.publish_project_deleted(
-            project_uuid=project_uuid,
-            user_email=user_email,
+            project_uuid=instance.uuid,
+            user_email=self.request.user.email,
         )
-
         instance.delete()
 
     @action(detail=True, methods=["POST"], url_name="set-type")


### PR DESCRIPTION
## What

Publishes project-deleted EDA events when an organization is destroyed via
`DELETE /v1/organization/org/{uuid}/`. Before deleting the organization (and
cascading project removal), the view iterates all projects and calls
`ProjectEDAPublisher.publish_project_deleted` with `request.user.email`.

Also simplifies the existing v2 project `perform_destroy` EDA call (same
behavior, fewer intermediate variables).

Adds unit test `OrganizationDestroyEDATestCase` with mocked publisher and
Intelligence client, verifying one event per project.

## Why

The front deletes organizations through the v1 org endpoint. That path removed
projects via DB cascade without notifying Retail, even though Retail already
consumes `action: "deleted"` on `update-projects.topic`.
