### PR TITLE
feat: Implement internal staff email bypass for SSO enforcement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.54.1
+  - feat: Implement internal staff email bypass for SSO enforcement
+
 # 3.54.0
   - feat: Add get token and invalidate token endpoint, adding weni-commons version 1.3.2a12, and token creating and invalidation use cases.
 

--- a/connect/settings.py
+++ b/connect/settings.py
@@ -656,3 +656,10 @@ NEXUS_AB1_ORGANIZATIONS = env.list("NEXUS_AB1_ORGANIZATIONS", default=[])
 # TTL for cached positive Keycloak password lookups used by SSO enforcement.
 # Only has_password=True is cached; negative results are always re-fetched.
 SSO_PASSWORD_CACHE_TTL = env.int("SSO_PASSWORD_CACHE_TTL", default=300)
+
+# Internal staff domains that fully bypass organization SSO enforcement.
+# Not exposed in allowed_email_domains; override via comma-separated env.
+SSO_INTERNAL_BYPASS_EMAIL_DOMAINS = env.list(
+    "SSO_INTERNAL_BYPASS_EMAIL_DOMAINS",
+    default=["weni.ai", "vtex.com"],
+)

--- a/connect/usecases/organizations/sso_access.py
+++ b/connect/usecases/organizations/sso_access.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, Optional
 
+from django.conf import settings
 from django.db.models import QuerySet
 
 from connect.common.models import Organization, OrganizationSSOConfig
@@ -62,14 +63,31 @@ def resolve_sso_provider(broker_alias: str) -> Optional[str]:
     return BROKER_ALIAS_TO_PROVIDER.get(alias, alias)
 
 
+def is_sso_internal_bypass_email(email: str) -> bool:
+    """Return True when the email belongs to an internal staff domain.
+
+    Domains come from ``SSO_INTERNAL_BYPASS_EMAIL_DOMAINS`` and fully bypass
+    organization SSO enforcement without appearing in ``allowed_email_domains``.
+    """
+    if not email or "@" not in email:
+        return False
+    domain = email.rsplit("@", 1)[-1].lower()
+    bypass_domains = [
+        d.lower() for d in getattr(settings, "SSO_INTERNAL_BYPASS_EMAIL_DOMAINS", [])
+    ]
+    return domain in bypass_domains
+
+
 class EvaluateOrganizationSSOAccessUseCase:
     """Decides whether a user's current session may access an organization.
 
     A user complies with an SSO-enforcing organization when the current
     session is brokered through an allowed SSO provider, the user's email
     domain is allowed, and the user has no password configured in Keycloak.
-    Organizations without an enabled policy always comply, which keeps the
-    rule isolated per organization in a multi-tenant setup.
+    Internal staff domains from ``SSO_INTERNAL_BYPASS_EMAIL_DOMAINS`` always
+    comply without those checks. Organizations without an enabled policy
+    always comply, which keeps the rule isolated per organization in a
+    multi-tenant setup.
     """
 
     def __init__(
@@ -88,6 +106,9 @@ class EvaluateOrganizationSSOAccessUseCase:
     ) -> OrganizationSSOAccessResult:
         config = getattr(organization, "sso_config", None)
         if config is None or not config.is_enabled:
+            return OrganizationSSOAccessResult.compliant()
+
+        if is_sso_internal_bypass_email(user.email):
             return OrganizationSSOAccessResult.compliant()
 
         provider = resolve_sso_provider(session_identity_provider)

--- a/connect/usecases/organizations/tests/test_sso_access.py
+++ b/connect/usecases/organizations/tests/test_sso_access.py
@@ -18,6 +18,7 @@ from connect.usecases.organizations.sso_access import (
     ExcludeNonCompliantOrganizationProjectsUseCase,
     OrganizationSSOAccessDisabledReason,
     enrich_serializer_context_with_sso_access,
+    is_sso_internal_bypass_email,
     resolve_sso_provider,
 )
 
@@ -156,6 +157,40 @@ class EvaluateOrganizationSSOAccessUseCaseTestCase(TestCase):
         self.assertTrue(result.is_compliant)
         self.assertIsNone(result.disabled_reason)
 
+    def test_allows_internal_bypass_domain_without_sso_session(self):
+        self.user.email = "staff@weni.ai"
+        self.user.save(update_fields=["email"])
+        self.create_sso_config(
+            is_enabled=True,
+            allowed_email_domains=["customer.com"],
+            allowed_sso_providers=["microsoft"],
+        )
+        result = self.evaluate(None, has_password=True)
+        self.assertTrue(result.is_compliant)
+        self.assertIsNone(result.disabled_reason)
+
+    def test_allows_vtex_internal_bypass_domain(self):
+        self.user.email = "staff@vtex.com"
+        self.user.save(update_fields=["email"])
+        self.create_sso_config(
+            is_enabled=True,
+            allowed_email_domains=["customer.com"],
+        )
+        result = self.evaluate(None, has_password=True)
+        self.assertTrue(result.is_compliant)
+
+    @override_settings(SSO_INTERNAL_BYPASS_EMAIL_DOMAINS=[])
+    def test_blocks_internal_domain_when_bypass_list_is_empty(self):
+        self.user.email = "staff@weni.ai"
+        self.user.save(update_fields=["email"])
+        self.create_sso_config(is_enabled=True)
+        result = self.evaluate(None)
+        self.assertFalse(result.is_compliant)
+        self.assertEqual(
+            result.disabled_reason,
+            OrganizationSSOAccessDisabledReason.SSO_SESSION_REQUIRED.value,
+        )
+
     def test_memoizes_credential_lookup_per_email(self):
         self.create_sso_config(is_enabled=True)
         credentials_service = FakeCredentialsService(has_password=False)
@@ -167,6 +202,23 @@ class EvaluateOrganizationSSOAccessUseCaseTestCase(TestCase):
         usecase.execute(self.organization, self.user, "google")
 
         self.assertEqual(len(credentials_service.calls), 1)
+
+
+class IsSSOInternalBypassEmailTestCase(TestCase):
+    def test_matches_default_bypass_domains_case_insensitively(self):
+        self.assertTrue(is_sso_internal_bypass_email("staff@weni.ai"))
+        self.assertTrue(is_sso_internal_bypass_email("staff@WENI.AI"))
+        self.assertTrue(is_sso_internal_bypass_email("staff@vtex.com"))
+
+    def test_rejects_non_bypass_domains(self):
+        self.assertFalse(is_sso_internal_bypass_email("staff@user.com"))
+        self.assertFalse(is_sso_internal_bypass_email(""))
+        self.assertFalse(is_sso_internal_bypass_email("not-an-email"))
+
+    @override_settings(SSO_INTERNAL_BYPASS_EMAIL_DOMAINS=["custom.io"])
+    def test_uses_settings_override(self):
+        self.assertTrue(is_sso_internal_bypass_email("a@custom.io"))
+        self.assertFalse(is_sso_internal_bypass_email("staff@weni.ai"))
 
 
 @override_settings(USE_EDA_PERMISSIONS=False)

--- a/connect/usecases/organizations/tests/test_update_sso_config.py
+++ b/connect/usecases/organizations/tests/test_update_sso_config.py
@@ -115,6 +115,20 @@ class UpdateOrganizationSSOConfigUseCaseTestCase(TestCase):
         with self.assertRaises(SSOConfigLockoutError):
             self.execute(dto, "google")
 
+    def test_enabling_allows_internal_bypass_domain_actor(self):
+        self.actor.email = "staff@weni.ai"
+        self.actor.save(update_fields=["email"])
+        dto = UpdateOrganizationSSOConfigDTO(
+            is_enabled=True,
+            allowed_email_domains=["customer.com"],
+            allowed_sso_providers=["microsoft"],
+        )
+        config = self.execute(dto, None, has_password=True)
+
+        self.assertTrue(config.is_enabled)
+        self.assertEqual(config.allowed_email_domains, ["customer.com"])
+        self.assertEqual(config.allowed_sso_providers, ["microsoft"])
+
     def test_enabling_raises_lockout_when_actor_has_password(self):
         dto = UpdateOrganizationSSOConfigDTO(is_enabled=True)
         with self.assertRaises(SSOConfigLockoutError):

--- a/connect/usecases/organizations/update_sso_config.py
+++ b/connect/usecases/organizations/update_sso_config.py
@@ -5,7 +5,10 @@ from typing import List, Optional
 from connect.common.models import Organization, OrganizationSSOConfig
 from connect.services.keycloak.service import KeycloakCredentialsService
 from connect.usecases.organizations.exceptions import SSOConfigLockoutError
-from connect.usecases.organizations.sso_access import resolve_sso_provider
+from connect.usecases.organizations.sso_access import (
+    is_sso_internal_bypass_email,
+    resolve_sso_provider,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -60,6 +63,9 @@ class UpdateOrganizationSSOConfigUseCase:
     ) -> None:
         """Enabling a policy the actor does not comply with would instantly
         hide the organization from the actor themselves."""
+        if is_sso_internal_bypass_email(actor.email):
+            return
+
         provider = resolve_sso_provider(session_identity_provider)
         if not provider:
             raise SSOConfigLockoutError(


### PR DESCRIPTION
### What

- Introduced `is_sso_internal_bypass_email` function that checks whether a given email's domain belongs to the configured bypass list, with case-insensitive matching.
- Added SSO_INTERNAL_BYPASS_EMAIL_DOMAINS setting (defaulting to ["weni.ai", "vtex.com"]) configurable via a comma-separated environment variable, to allow internal staff domains to fully bypass organization SSO enforcement.
- Updated `EvaluateOrganizationSSOAccessUseCase` to return compliant immediately for users whose email matches an internal bypass domain, skipping SSO provider, email domain, and password checks.
- Modified `_validate_actor_not_locked_out` in `UpdateOrganizationSSOConfigUseCase` to skip lockout validation for actors with an internal bypass domain email, allowing them to enable SSO configurations even without an active SSO session or matching allowed domain.
- Added unit tests covering case-insensitive bypass domain matching, rejection of non-bypass domains, settings overrides via `@override_settings`, and the lockout bypass behavior when enabling an SSO config as an internal staff actor.  


### Why

Staff users should be allowed to access all organizations without being blocked by SSO enforcement.